### PR TITLE
docs: specialize ai guideline files for dream duels

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,11 @@
 # Guidelines for AI Agents
 
-This project is a generic Node.js project template using pnpm.
-It supports both monorepo and non-monorepo configurations,
-providing a common foundation that can be specialized for either
-structure. It is derived from the language-independent
-[template](https://github.com/kurone-kito/template) repository.
+This is **Dream Duels: The Battle for Oneiron** — a table-talk battle
+royale card game implemented as a pnpm monorepo. The `packages/core`
+workspace holds the npm-publishable rule engine; `packages/web` holds
+the web-based simulator. The project is derived from
+[`kurone-kito/pnpm-project-template`](https://github.com/kurone-kito/pnpm-project-template)
+and has been customized for this game.
 
 When contributing to this repository using AI agents, adhere to the
 following guidelines to ensure high-quality contributions that align
@@ -294,57 +295,19 @@ These rules follow the
   the AI to review its own output and suggest improvements before
   accepting
 
-## Onboarding
+## Project status and IDD workflow
 
-This project template is a Node.js / pnpm specific derivative of the
-generic [template](https://github.com/kurone-kito/template).
-If you plan to customize this template for a different framework or
-toolchain, **submit a proposal to update the documentation first**.
+This repository has been onboarded. AI guideline files, README, and
+rules documentation have been customized for Dream Duels. Follow-up
+issues are completing the multi-agent IDD (Issue-Driven Development)
+workflow setup. Once those issues land, the following files will be
+present:
 
-### Derived-repository detection
+- `docs/idd-policy.md` — recorded IDD policy decisions
+- `docs/idd-workflow.md` — cross-agent IDD workflow entry path
+- `.github/instructions/idd-overview.instructions.md` — phase routing
 
-When an AI agent starts a session, it should determine whether this
-repository is the **base template** or a **derived project**:
-
-1. **Check the repository name** — inspect the git remote URL
-   (e.g., `git remote get-url origin`), the working-directory name,
-   or any GitHub API context available to the agent. If the
-   repository name is exactly `pnpm-project-template`, treat it as
-   the base template. Any other name indicates a derived project.
-2. **Check for generic content** — look for the sentinel phrase
-   `generic Node.js project template using pnpm` in this file or
-   in the repository's AI instruction files. Its presence means the
-   guidelines have **not yet been customized**.
-
-If both conditions are met — the repository is derived **and** the
-guidelines are still generic — the agent should **proactively
-propose an onboarding workflow** before proceeding with the user's
-request. The proposal should be conversational, brief, and
-non-blocking (the user may decline and continue normally).
-
-### Onboarding proposal
-
-When proposing onboarding, suggest customizing the following areas
-in a single plan:
-
-1. **Project description** — update `README.md` and the opening
-   lines of AI instruction files to reflect the project's purpose
-2. **Framework / toolchain** — identify the primary framework;
-   add relevant build tooling and type definitions
-3. **Dependency management** — configure workspace structure and
-   lock-file conventions as needed
-4. **Testing strategy** — define the test runner, coverage targets,
-   and test-file conventions
-5. **CI/CD workflows** — adjust `.github/workflows/` to match the
-   project's build, test, and deploy pipeline
-6. **AI guideline specialization** — rewrite this file,
-   `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` to include
-   project-specific rules, coding patterns, and architecture notes
-7. **README rewrite** — replace the template README with
-   project-specific content (badges, installation, usage, etc.)
-8. **License review** — confirm or replace the MIT license if the
-   project requires a different one
-
-Present these items as a checklist proposal (e.g., in Plan mode for
-Copilot, or as a numbered list for other agents). Let the user
-select which items to tackle and in what order.
+When those files are present, open `docs/idd-workflow.md` as the
+cross-agent entry path before starting IDD work, and open
+`.github/instructions/idd-overview.instructions.md` before each
+phase change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,10 @@
 # Guidelines for AI Agents
 
-This project is a generic Node.js project template using pnpm.
-It is currently optimized for GitHub Copilot tooling, but `AGENTS.md`
-exists so Codex can still receive the minimum project rules
-immediately, without depending on a redirect.
+This is **Dream Duels: The Battle for Oneiron** — a table-talk battle
+royale card game implemented as a pnpm monorepo (`packages/core` for the
+rule engine, `packages/web` for the simulator). It is optimized for
+GitHub Copilot tooling, but `AGENTS.md` exists so Codex can receive the
+minimum project rules immediately, without depending on a redirect.
 
 ## Setup commands
 
@@ -54,21 +55,14 @@ A `.gitmessage` template is available at the repository root.
 Write user-facing, lowercase subjects, keep them under 72 characters,
 and split unrelated changes into separate atomic commits.
 
-## Onboarding detection
+## Project status
 
-When starting a session, check whether this repository is the base
-template or a derived project:
+This repository has been onboarded and customized from the
+`kurone-kito/pnpm-project-template` base. The IDD workflow setup is in
+progress via follow-up issues. When available:
 
-- If the repository name is exactly `oneiron`, it is
-  the base template — no action needed.
-- If the name differs **and** this file still contains the phrase
-  `generic Node.js project template using pnpm`, the guidelines
-  have not been customized yet.
-
-In that case, **proactively propose an onboarding workflow** to
-customize the project's documentation, tooling, and AI guidelines.
-See the full onboarding checklist in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
+- `docs/idd-policy.md` — recorded IDD policy decisions
+- `docs/idd-workflow.md` — cross-agent IDD workflow entry path
 
 ## Canonical reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,11 @@
 # Guidelines for AI Agents
 
-This project is a generic Node.js project template using pnpm.
-It is currently optimized for GitHub Copilot tooling, but `CLAUDE.md`
-exists so Claude Code can still receive the minimum project rules
-immediately, without depending on a redirect.
+This is **Dream Duels: The Battle for Oneiron** — a table-talk battle
+royale card game implemented as a pnpm monorepo (`packages/core` for the
+rule engine, `packages/web` for the simulator). It is optimized for
+GitHub Copilot tooling, but `CLAUDE.md` exists so Claude Code can
+receive the minimum project rules immediately, without depending on a
+redirect.
 
 ## Setup commands
 
@@ -54,21 +56,14 @@ A `.gitmessage` template is available at the repository root.
 Write user-facing, lowercase subjects, keep them under 72 characters,
 and split unrelated changes into separate atomic commits.
 
-## Onboarding detection
+## Project status
 
-When starting a session, check whether this repository is the base
-template or a derived project:
+This repository has been onboarded and customized from the
+`kurone-kito/pnpm-project-template` base. The IDD workflow setup is in
+progress via follow-up issues. When available:
 
-- If the repository name is exactly `oneiron`, it is
-  the base template — no action needed.
-- If the name differs **and** this file still contains the phrase
-  `generic Node.js project template using pnpm`, the guidelines
-  have not been customized yet.
-
-In that case, **proactively propose an onboarding workflow** to
-customize the project's documentation, tooling, and AI guidelines.
-See the full onboarding checklist in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
+- `docs/idd-policy.md` — recorded IDD policy decisions
+- `docs/idd-workflow.md` — cross-agent IDD workflow entry path
 
 ## Canonical reference
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,9 +1,10 @@
 # Guidelines for AI Agents
 
-This project is a generic Node.js project template using pnpm.
-It is currently optimized for GitHub Copilot tooling, but `GEMINI.md`
-exists so Gemini CLI can still receive the minimum project rules
-immediately, without depending on a redirect.
+This is **Dream Duels: The Battle for Oneiron** — a table-talk battle
+royale card game implemented as a pnpm monorepo (`packages/core` for the
+rule engine, `packages/web` for the simulator). It is optimized for
+GitHub Copilot tooling, but `GEMINI.md` exists so Gemini CLI can receive
+the minimum project rules immediately, without depending on a redirect.
 
 ## Setup commands
 
@@ -54,26 +55,19 @@ A `.gitmessage` template is available at the repository root.
 Write user-facing, lowercase subjects, keep them under 72 characters,
 and split unrelated changes into separate atomic commits.
 
-## Onboarding detection
+## Project status
 
-When starting a session, check whether this repository is the base
-template or a derived project:
+This repository has been onboarded and customized from the
+`kurone-kito/pnpm-project-template` base. The IDD workflow setup is in
+progress via follow-up issues. When available:
 
-- If the repository name is exactly `oneiron`, it is
-  the base template — no action needed.
-- If the name differs **and** this file still contains the phrase
-  `generic Node.js project template using pnpm`, the guidelines
-  have not been customized yet.
-
-In that case, **proactively propose an onboarding workflow** to
-customize the project's documentation, tooling, and AI guidelines.
-See the full onboarding checklist in
-[.github/copilot-instructions.md](.github/copilot-instructions.md).
+- `docs/idd-policy.md` — recorded IDD policy decisions
+- `docs/idd-workflow.md` — cross-agent IDD workflow entry path
 
 ## Canonical reference
 
 The full, Copilot-first project guidance lives in
 [.github/copilot-instructions.md](.github/copilot-instructions.md).
 When that file uses Copilot-specific workflow names, apply the intent
-in Gemini CLI using its own interaction model rather than following
-the product terms literally.
+in Gemini CLI using its own interaction model rather than following the
+product terms literally.

--- a/docs/ai-strategy.md
+++ b/docs/ai-strategy.md
@@ -1,8 +1,8 @@
 # AI tooling strategy
 
-This repository currently prioritizes GitHub Copilot because it
-provides the best latency and workflow fit for day-to-day vibe coding
-in this template.
+This repository prioritizes GitHub Copilot for day-to-day development
+on **Dream Duels: The Battle for Oneiron**, a table-talk battle royale
+card game implemented as a pnpm monorepo.
 
 ## Canonical guidance
 
@@ -29,16 +29,12 @@ in this template.
   underlying intent so other agents can map it to their own interaction
   model.
 
-## Onboarding detection
+## Onboarding status
 
-When the repository name is not `oneiron` and the AI
-instruction files still contain the generic sentinel phrase, AI agents
-should proactively propose a customization workflow. This keeps the
-template's "vibe-coding ready" promise alive in derived projects by
-guiding users through documentation, tooling, and guideline
-specialization immediately after they create a new repository from
-the template. The full onboarding checklist is maintained in
-`.github/copilot-instructions.md` § Onboarding.
+This repository has been onboarded and customized. The pnpm-template
+sentinel phrase has been removed and the AI guideline files now describe
+Dream Duels specifically. Follow-up issues are completing the IDD
+workflow setup (`docs/idd-policy.md`, `docs/idd-workflow.md`).
 
 ## Maintenance notes
 


### PR DESCRIPTION
## Summary

- Replace template description with Dream Duels project identity in `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, `.github/copilot-instructions.md`
- Remove broken onboarding-detection sentences (`oneiron` was wrongly flagged as the base template)
- Update `docs/ai-strategy.md` to reflect customized state
- Add forward-references to future `docs/idd-policy.md` and `docs/idd-workflow.md`

## Why

All four agent entry files still said "generic Node.js project template using pnpm." The broken detection logic in `CLAUDE.md`/`AGENTS.md` would have caused future AI agents to skip onboarding even for freshly checked-out sessions of the customized project.

## Self-review notes (C phase — enhanced; Copilot advisory unavailable)

- Verified: `grep "generic Node.js project template using pnpm"` returns no matches
- Boundaries, coding-standards, and commit-rule sections preserved unchanged
- IDD workflow section deferred to the idd-skill import issue (per scope note in issue body)
- No README, package.json, or workspace file touched

## Test plan

- [ ] `pnpm run lint` passes (CI)
- [ ] No file contains the sentinel phrase (grep check above)
- [ ] Dream Duels description appears in opening section of all four files

Closes #47

🤖 Generated with [Claude Code](https://claude.ai/claude-code)