### PR TITLE
chore: declare pnpm workspace under packages/*

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "packages/*"
+
 configDependencies:
   '@pnpm/plugin-types-fixer': 0.1.0+sha512-bLww63gRHi7siYTqFJb5qNdcXadU0jv20Et6z5AryMZ7FlLolbEJOrXLpg8+amQZNHHNW1dfFUBGVw/9ezQbFg==
 shellEmulator: true


### PR DESCRIPTION
## Summary

Add `packages: ["packages/*"]` to `pnpm-workspace.yaml` so follow-up issues can scaffold `@kurone-kito/oneiron-core` and `@kurone-kito/oneiron-web` as proper workspace members.

## Self-review (C phase — enhanced)

- Single-line YAML addition; `configDependencies` and `shellEmulator` preserved ✓
- `pnpm install` confirmed working with no warnings ✓
- `pnpm list --recursive` shows root package only (no packages yet, expected) ✓
- No other files touched ✓

Closes #48

🤖 Generated with [Claude Code](https://claude.ai/claude-code)