### PR TITLE
ci: extend push workflow for the new workspace shape

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,6 @@
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  cancel-in-progress: true
 name: The CI workflow on push
 on:
   push:
@@ -35,6 +35,10 @@ jobs:
           HUSKY: 0
         name: Install the dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
+      - name: Run the linter
+        run: pnpm run lint
+      - name: Run the type checker
+        run: pnpm -r run typecheck
       - name: Run the tests
         run: pnpm run test
     strategy:
@@ -58,4 +62,4 @@ jobs:
             shell: bash
           - os: windows-latest
             shell: powershell
-    timeout-minutes: 5
+    timeout-minutes: 10

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@kurone-kito/typescript-config",
   "compilerOptions": {
     "noEmit": true,
-    "rootDir": "src"
+    "rootDir": "src",
+    "types": []
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@kurone-kito/oneiron-core": "workspace:*",

--- a/packages/web/tsconfig.json
+++ b/packages/web/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@kurone-kito/typescript-config",
   "compilerOptions": {
     "jsx": "preserve",
-    "jsxImportSource": "solid-js"
+    "jsxImportSource": "solid-js",
+    "lib": ["dom", "dom.iterable", "esnext"]
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
## Summary

- Add lint step (`pnpm run lint`) before the test step
- Add typecheck step (`pnpm -r run typecheck`) for all workspace packages
- Set `cancel-in-progress: true` (was conditional on PR refs only)
- Increase `timeout-minutes: 5 → 10` for additional steps
- Add `typecheck` script to `packages/web` with DOM lib config
- Fix `packages/core` typecheck: exclude test files that transitively import vite types (which are incompatible with rollup under `exactOptionalPropertyTypes`)

## Why

The lint step disappeared after #51 changed `pnpm run test` from `pnpm run lint` to `vitest run`. The typecheck was never in CI. Both are needed for a healthy monorepo gate.

## Self-review (C phase — enhanced)

- `pnpm -r run typecheck` passes for both core and web ✓
- `pnpm run lint` passes ✓
- `pnpm run test` (vitest) still passes ✓
- Test files excluded from core typecheck to avoid vite/rollup type incompatibility under exactOptionalPropertyTypes ✓
- Concurrency group now always cancels redundant runs ✓

Closes #52

🤖 Generated with [Claude Code](https://claude.ai/claude-code)