### PR TITLE
feat(core): define token models (LifeToken, NumberToken)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,2 @@
 export * from './types/card.ts';
+export * from './types/token.ts';

--- a/packages/core/src/types/token.test.ts
+++ b/packages/core/src/types/token.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chargeLife,
+  createLifeToken,
+  drainLife,
+  isAlive,
+  LIFE_MAX,
+  LIFE_MIN,
+  type LifeToken,
+  type NumberToken,
+  type TeamId,
+} from './token.ts';
+
+describe('createLifeToken', () => {
+  it('returns the value as-is for valid inputs', () => {
+    expect(createLifeToken(0)).toBe(0);
+    expect(createLifeToken(2)).toBe(2);
+    expect(createLifeToken(4)).toBe(4);
+  });
+  it('clamps to LIFE_MIN for values below 0', () => {
+    expect(createLifeToken(-1)).toBe(LIFE_MIN);
+    expect(createLifeToken(-100)).toBe(LIFE_MIN);
+  });
+  it('clamps to LIFE_MAX for values above 4', () => {
+    expect(createLifeToken(5)).toBe(LIFE_MAX);
+    expect(createLifeToken(100)).toBe(LIFE_MAX);
+  });
+});
+
+describe('isAlive', () => {
+  it('returns true when life is above zero', () => {
+    expect(isAlive(1 as LifeToken)).toBe(true);
+    expect(isAlive(4 as LifeToken)).toBe(true);
+  });
+  it('returns false when life is zero', () => {
+    expect(isAlive(0 as LifeToken)).toBe(false);
+  });
+});
+
+describe('chargeLife', () => {
+  it('adds life normally', () => {
+    expect(chargeLife(2 as LifeToken, 1)).toBe(3);
+  });
+  it('clamps at LIFE_MAX by default', () => {
+    expect(chargeLife(3 as LifeToken, 5)).toBe(LIFE_MAX);
+  });
+  it('clamps at a custom max', () => {
+    expect(chargeLife(2 as LifeToken, 3, 3 as LifeToken)).toBe(3);
+  });
+  it('does not go below current value when n is 0', () => {
+    expect(chargeLife(2 as LifeToken, 0)).toBe(2);
+  });
+});
+
+describe('drainLife', () => {
+  it('subtracts life normally', () => {
+    expect(drainLife(3 as LifeToken, 1)).toBe(2);
+  });
+  it('clamps at LIFE_MIN (0)', () => {
+    expect(drainLife(1 as LifeToken, 10)).toBe(LIFE_MIN);
+  });
+  it('does not change value when n is 0', () => {
+    expect(drainLife(3 as LifeToken, 0)).toBe(3);
+  });
+  it('eliminates player when drained to exactly 0', () => {
+    expect(drainLife(2 as LifeToken, 2)).toBe(0);
+  });
+});
+
+describe('type exports', () => {
+  it('NumberToken accepts 1–10', () => {
+    const t: NumberToken = 5;
+    expect(t).toBe(5);
+  });
+  it('TeamId is an alias for NumberToken', () => {
+    const id: TeamId = 3;
+    expect(id).toBe(3);
+  });
+});

--- a/packages/core/src/types/token.ts
+++ b/packages/core/src/types/token.ts
@@ -1,0 +1,35 @@
+/** Life token value for one player: 0 (eliminated) through 4 (full health). */
+export type LifeToken = 0 | 1 | 2 | 3 | 4;
+
+/** Number token value: uniquely identifies one of the 1–10 teams on the grid. */
+export type NumberToken = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
+
+/** A team is identified by its number token value. */
+export type TeamId = NumberToken;
+
+export const LIFE_MAX: LifeToken = 4;
+export const LIFE_MIN: LifeToken = 0;
+
+/** Creates a LifeToken clamped to [0, 4]. */
+export function createLifeToken(n: number): LifeToken {
+  return Math.min(Math.max(n, LIFE_MIN), LIFE_MAX) as LifeToken;
+}
+
+/** Returns true when the player still has life tokens remaining. */
+export function isAlive(token: LifeToken): boolean {
+  return token > LIFE_MIN;
+}
+
+/** Adds n life, clamped to max (default 4). */
+export function chargeLife(
+  token: LifeToken,
+  n: number,
+  max: LifeToken = LIFE_MAX,
+): LifeToken {
+  return Math.min(token + n, max) as LifeToken;
+}
+
+/** Subtracts n life, clamped to 0. */
+export function drainLife(token: LifeToken, n: number): LifeToken {
+  return Math.max(token - n, LIFE_MIN) as LifeToken;
+}


### PR DESCRIPTION
Closes #67

## Summary

- Add `LifeToken` (value type `0|1|2|3|4`) and `NumberToken` (`1–10`) types in `packages/core/src/types/token.ts`
- Add `TeamId` as an alias for `NumberToken`
- Implement `createLifeToken` (clamped constructor), `isAlive`, `chargeLife` (with optional custom max), and `drainLife` helpers
- Re-export all new symbols from `packages/core/src/index.ts`
- 15 Vitest tests covering bounds, clamping, and alive-state transitions

## Test plan

- [x] `pnpm run test` — 23 tests pass (15 new, 8 from card types)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token type system for managing life points, numbered identifiers, and team assignments with built-in validation and constraints.
  * Added utility functions for life management: create tokens from numeric values, check if alive, charge (increase) life, and drain (decrease) life.

* **Tests**
  * Added comprehensive test suite for token utilities covering validation, clamping, and type safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->