### PR TITLE
feat(core): define 3x3 grid coordinate model

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
 export * from './types/card.ts';
+export * from './types/grid.ts';
 export * from './types/token.ts';

--- a/packages/core/src/types/grid.test.ts
+++ b/packages/core/src/types/grid.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import type { GridCoord } from './grid.ts';
+import { isAdjacent, isSameCoord, rotate } from './grid.ts';
+
+const fireWater: GridCoord = { x: 'fire', y: 'water' };
+const waterWater: GridCoord = { x: 'water', y: 'water' };
+const woodWater: GridCoord = { x: 'wood', y: 'water' };
+const fireWood: GridCoord = { x: 'fire', y: 'wood' };
+const fireFire: GridCoord = { x: 'fire', y: 'fire' };
+const waterWood: GridCoord = { x: 'water', y: 'wood' };
+
+describe('isSameCoord', () => {
+  it('returns true for identical coordinates', () => {
+    expect(isSameCoord(fireWater, { x: 'fire', y: 'water' })).toBe(true);
+  });
+  it('returns false when x differs', () => {
+    expect(isSameCoord(fireWater, waterWater)).toBe(false);
+  });
+  it('returns false when y differs', () => {
+    expect(isSameCoord(fireWater, fireWood)).toBe(false);
+  });
+  it('returns false when both differ', () => {
+    expect(isSameCoord(fireWater, waterWood)).toBe(false);
+  });
+});
+
+describe('isAdjacent', () => {
+  it('returns true when only x differs by one step', () => {
+    expect(isAdjacent(fireWater, waterWater)).toBe(true);
+    expect(isAdjacent(waterWater, woodWater)).toBe(true);
+  });
+  it('returns true when only y differs by one step', () => {
+    expect(isAdjacent(fireFire, fireWater)).toBe(true);
+    expect(isAdjacent(fireWater, fireWood)).toBe(true);
+  });
+  it('returns false for the same cell', () => {
+    expect(isAdjacent(fireWater, fireWater)).toBe(false);
+  });
+  it('returns false for diagonal cells', () => {
+    expect(isAdjacent(fireFire, waterWater)).toBe(false);
+  });
+  it('returns false when x distance is 2 (fire–wood)', () => {
+    expect(isAdjacent(fireFire, { x: 'wood', y: 'fire' })).toBe(false);
+  });
+  it('returns false when y distance is 2 (fire–wood)', () => {
+    expect(isAdjacent(fireFire, { x: 'fire', y: 'wood' })).toBe(false);
+  });
+});
+
+describe('rotate', () => {
+  it('rotates clockwise correctly through all facings', () => {
+    expect(rotate('north', 'cw')).toBe('east');
+    expect(rotate('east', 'cw')).toBe('south');
+    expect(rotate('south', 'cw')).toBe('west');
+    expect(rotate('west', 'cw')).toBe('north');
+  });
+  it('rotates counter-clockwise correctly through all facings', () => {
+    expect(rotate('north', 'ccw')).toBe('west');
+    expect(rotate('west', 'ccw')).toBe('south');
+    expect(rotate('south', 'ccw')).toBe('east');
+    expect(rotate('east', 'ccw')).toBe('north');
+  });
+  it('two cw steps equal one 180° turn', () => {
+    expect(rotate(rotate('north', 'cw'), 'cw')).toBe('south');
+  });
+  it('cw then ccw returns to original', () => {
+    expect(rotate(rotate('east', 'cw'), 'ccw')).toBe('east');
+  });
+});

--- a/packages/core/src/types/grid.ts
+++ b/packages/core/src/types/grid.ts
@@ -1,0 +1,71 @@
+import type { Deck, Element } from './card.ts';
+import type { LifeToken, NumberToken } from './token.ts';
+
+/** Element value used as a grid axis coordinate. */
+export type ElementCoordinate = Element;
+
+/** A position on the 3×3 board, identified by element on each axis. */
+export type GridCoord = {
+  readonly x: ElementCoordinate;
+  readonly y: ElementCoordinate;
+};
+
+/** Cardinal direction a team faces on the board. */
+export type Facing = 'east' | 'north' | 'south' | 'west';
+
+/** Rotation step direction: clockwise or counter-clockwise. */
+export type RotateDir = 'ccw' | 'cw';
+
+/** Per-player state tracked within a team. */
+export type PlayerState = {
+  readonly life: LifeToken;
+};
+
+/** Full state for one team occupying the board. */
+export type TeamState = {
+  readonly position: GridCoord;
+  readonly facing: Facing;
+  readonly cards: Deck;
+  readonly teamNumber: NumberToken;
+  readonly players: readonly PlayerState[];
+};
+
+/** All teams currently standing on one grid cell. */
+export type GridCell = readonly TeamState[];
+
+/** The 3×3 board: `grid[x][y]` holds the teams at coordinate (x, y). */
+export type Grid = Readonly<
+  Record<ElementCoordinate, Readonly<Record<ElementCoordinate, GridCell>>>
+>;
+
+/** Ordered axis positions: fire=0, water=1, wood=2. */
+const ELEMENT_AXIS: readonly ElementCoordinate[] = ['fire', 'water', 'wood'];
+
+/** Clockwise facing order. */
+const FACING_CW: readonly Facing[] = ['north', 'east', 'south', 'west'];
+
+function axisDistance(a: ElementCoordinate, b: ElementCoordinate): number {
+  return Math.abs(ELEMENT_AXIS.indexOf(a) - ELEMENT_AXIS.indexOf(b));
+}
+
+/** Returns true when the two grid coords refer to the same cell. */
+export function isSameCoord(a: GridCoord, b: GridCoord): boolean {
+  return a.x === b.x && a.y === b.y;
+}
+
+/**
+ * Returns true when two cells share an edge.
+ * Diagonal cells and cells two or more steps apart are not adjacent.
+ */
+export function isAdjacent(a: GridCoord, b: GridCoord): boolean {
+  const dx = axisDistance(a.x, b.x);
+  const dy = axisDistance(a.y, b.y);
+  return (dx === 1 && dy === 0) || (dx === 0 && dy === 1);
+}
+
+/** Rotates facing one step clockwise ('cw') or counter-clockwise ('ccw'). */
+export function rotate(facing: Facing, dir: RotateDir): Facing {
+  const i = FACING_CW.indexOf(facing);
+  const offset = dir === 'cw' ? 1 : -1;
+  return FACING_CW[(i + offset + 4) % 4] as Facing;
+}


### PR DESCRIPTION
Closes #68

Depends on #82 (token models) — branched from that PR's branch.

## Summary

- Add `ElementCoordinate`, `GridCoord`, `Facing`, `RotateDir` types in `packages/core/src/types/grid.ts`
- Add `PlayerState`, `TeamState`, `GridCell`, and `Grid` composite types
- Implement `isSameCoord`, `isAdjacent` (edge-only, no diagonal), and `rotate` (cw/ccw) utilities
- Axis element ordering: `fire=0, water=1, wood=2` — fire↔water and water↔wood are adjacent; fire↔wood is not
- Re-export all new symbols from `packages/core/src/index.ts`
- 14 Vitest tests covering all utility functions and boundary cases

## Test plan

- [x] `pnpm run test` — 37 tests pass (14 new + 23 from prior types)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)