### PR TITLE
feat(core): implement rock-paper-scissors card resolution

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './config.ts';
+export * from './logic/resolve.ts';
 export * from './types/card.ts';
 export * from './types/grid.ts';
 export * from './types/token.ts';

--- a/packages/core/src/logic/resolve.test.ts
+++ b/packages/core/src/logic/resolve.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import type { ElementCard, JokerCard } from '../types/card.ts';
+import { resolveCards } from './resolve.ts';
+
+const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+const fire9: ElementCard = { kind: 'element', element: 'fire', value: 9 };
+const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+const water7: ElementCard = { kind: 'element', element: 'water', value: 7 };
+const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+const wood12: ElementCard = { kind: 'element', element: 'wood', value: 12 };
+const joker: JokerCard = { kind: 'joker' };
+
+describe('resolveCards — joker rules', () => {
+  it('joker vs joker is a draw', () => {
+    expect(resolveCards(joker, joker)).toBe('draw');
+  });
+  it('joker beats fire', () => {
+    expect(resolveCards(joker, fire5)).toBe('a');
+    expect(resolveCards(fire5, joker)).toBe('b');
+  });
+  it('joker beats water', () => {
+    expect(resolveCards(joker, water3)).toBe('a');
+    expect(resolveCards(water3, joker)).toBe('b');
+  });
+  it('joker beats wood', () => {
+    expect(resolveCards(joker, wood1)).toBe('a');
+    expect(resolveCards(wood1, joker)).toBe('b');
+  });
+});
+
+describe('resolveCards — element matchups', () => {
+  it('fire beats wood', () => {
+    expect(resolveCards(fire5, wood1)).toBe('a');
+    expect(resolveCards(wood12, fire9)).toBe('b');
+  });
+  it('wood beats water', () => {
+    expect(resolveCards(wood1, water3)).toBe('a');
+    expect(resolveCards(water7, wood12)).toBe('b');
+  });
+  it('water beats fire', () => {
+    expect(resolveCards(water3, fire5)).toBe('a');
+    expect(resolveCards(fire9, water7)).toBe('b');
+  });
+});
+
+describe('resolveCards — draws', () => {
+  it('same element is a draw regardless of value', () => {
+    expect(resolveCards(fire5, fire9)).toBe('draw');
+    expect(resolveCards(water3, water7)).toBe('draw');
+    expect(resolveCards(wood1, wood12)).toBe('draw');
+  });
+});

--- a/packages/core/src/logic/resolve.ts
+++ b/packages/core/src/logic/resolve.ts
@@ -1,0 +1,41 @@
+import type { Card } from '../types/card.ts';
+import { ELEMENT_BEATS, isElementCard, isJokerCard } from '../types/card.ts';
+
+/** Outcome of a card-vs-card comparison from player A's perspective. */
+export type ResolutionResult = 'a' | 'b' | 'draw';
+
+/**
+ * Resolves which card wins in a head-to-head encounter.
+ *
+ * Rules:
+ * - Joker beats any ElementCard; Joker vs Joker is a draw.
+ * - Element vs Element: fire > wood > water > fire; same element is a draw.
+ *
+ * Returns 'a' if card a wins, 'b' if card b wins, 'draw' otherwise.
+ */
+export function resolveCards(a: Card, b: Card): ResolutionResult {
+  const aIsJoker = isJokerCard(a);
+  const bIsJoker = isJokerCard(b);
+
+  if (aIsJoker && bIsJoker) {
+    return 'draw';
+  }
+  if (aIsJoker) {
+    return 'a';
+  }
+  if (bIsJoker) {
+    return 'b';
+  }
+
+  if (isElementCard(a) && isElementCard(b)) {
+    if (ELEMENT_BEATS[a.element] === b.element) {
+      return 'a';
+    }
+    if (ELEMENT_BEATS[b.element] === a.element) {
+      return 'b';
+    }
+    return 'draw';
+  }
+
+  return 'draw';
+}


### PR DESCRIPTION
Closes #69

## Summary

- Add `resolveCards(a, b): ResolutionResult` in `src/logic/resolve.ts`
- Rules: joker beats any element; joker vs joker draws; fire > wood > water > fire; same element draws
- Export `ResolutionResult` type (`'a' | 'b' | 'draw'`)
- Re-export from `src/index.ts`
- 8 tests covering all 9 element matchups + 4 joker combinations (both directions)

## Test plan

- [x] `pnpm run test` — 52 tests pass (8 new)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)