### PR TITLE
feat(core): implement 4-phase round state machine

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './config.ts';
 export * from './logic/resolve.ts';
+export * from './logic/round.ts';
 export * from './types/card.ts';
 export * from './types/grid.ts';
 export * from './types/token.ts';

--- a/packages/core/src/logic/round.test.ts
+++ b/packages/core/src/logic/round.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import type { ElementCard } from '../types/card.ts';
+import type { Facing, GridCoord, TeamState } from '../types/grid.ts';
+import type { LifeToken, NumberToken } from '../types/token.ts';
+import type { RoundState } from './round.ts';
+import {
+  advanceBattle,
+  advanceForbidden,
+  advanceMovement,
+  advanceRevival,
+  createEmptyGrid,
+  isGameOver,
+  winner,
+} from './round.ts';
+
+function makeTeam(
+  id: NumberToken,
+  pos: GridCoord,
+  facing: Facing = 'north',
+  life: LifeToken = 2,
+): TeamState {
+  return {
+    teamNumber: id,
+    position: pos,
+    facing,
+    cards: [],
+    players: [{ life }],
+  };
+}
+
+function stateWith(teams: TeamState[]): RoundState {
+  let grid = createEmptyGrid();
+  for (const team of teams) {
+    const { x, y } = team.position;
+    const cell = [...grid[x][y], team];
+    grid = { ...grid, [x]: { ...grid[x], [y]: cell } } as typeof grid;
+  }
+  return { phase: 'battle', round: 1, grid, forbiddenCells: [] };
+}
+
+const fireWater: GridCoord = { x: 'fire', y: 'water' };
+const waterWater: GridCoord = { x: 'water', y: 'water' };
+const woodWater: GridCoord = { x: 'wood', y: 'water' };
+const fireWood: GridCoord = { x: 'fire', y: 'wood' };
+const fireFire: GridCoord = { x: 'fire', y: 'fire' };
+
+describe('createEmptyGrid', () => {
+  it('returns a 3×3 grid with no teams', () => {
+    const g = createEmptyGrid();
+    expect(g.fire.fire).toEqual([]);
+    expect(g.water.wood).toEqual([]);
+    expect(g.wood.water).toEqual([]);
+  });
+});
+
+describe('isGameOver', () => {
+  it('returns true when no teams are alive', () => {
+    expect(isGameOver(stateWith([]))).toBe(true);
+  });
+  it('returns true when exactly one team is alive', () => {
+    const s = stateWith([makeTeam(1 as NumberToken, fireWater)]);
+    expect(isGameOver(s)).toBe(true);
+  });
+  it('returns false when two or more teams are alive', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireWater),
+      makeTeam(2 as NumberToken, waterWater),
+    ]);
+    expect(isGameOver(s)).toBe(false);
+  });
+  it('treats teams with zero life as dead', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireWater, 'north', 0 as LifeToken),
+      makeTeam(2 as NumberToken, waterWater),
+    ]);
+    expect(isGameOver(s)).toBe(true);
+  });
+});
+
+describe('winner', () => {
+  it('returns null when no teams survive', () => {
+    expect(winner(stateWith([]))).toBeNull();
+  });
+  it('returns the surviving team id', () => {
+    const s = stateWith([makeTeam(3 as NumberToken, fireWater)]);
+    expect(winner(s)).toBe(3);
+  });
+  it('returns null when two teams survive (no winner yet)', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireWater),
+      makeTeam(2 as NumberToken, waterWater),
+    ]);
+    expect(winner(s)).toBeNull();
+  });
+});
+
+describe('advanceBattle', () => {
+  it('returns empty when no teams are on the grid', () => {
+    expect(advanceBattle(stateWith([]))).toEqual([]);
+  });
+  it('identifies same-cell encounters', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireWater),
+      makeTeam(2 as NumberToken, fireWater),
+    ]);
+    const results = advanceBattle(s);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.encounterType).toBe('same-cell');
+  });
+  it('identifies adjacent encounters', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireWater),
+      makeTeam(2 as NumberToken, waterWater),
+    ]);
+    const results = advanceBattle(s);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.encounterType).toBe('adjacent');
+  });
+  it('does not list non-adjacent, non-same teams', () => {
+    const s = stateWith([
+      makeTeam(1 as NumberToken, fireFire),
+      makeTeam(2 as NumberToken, woodWater),
+    ]);
+    expect(advanceBattle(s)).toEqual([]);
+  });
+});
+
+describe('advanceForbidden', () => {
+  it('advances phase to movement', () => {
+    const s = stateWith([]);
+    const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+    const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+    const next = advanceForbidden(s, [fire5, water3]);
+    expect(next.phase).toBe('movement');
+  });
+  it('adds the new forbidden cell based on card elements', () => {
+    const s = stateWith([]);
+    const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+    const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+    const next = advanceForbidden(s, [fire5, water3]);
+    expect(next.forbiddenCells).toContainEqual({ x: 'fire', y: 'water' });
+  });
+  it('accumulates multiple forbidden cells', () => {
+    const s = stateWith([]);
+    const c1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
+    const c2: ElementCard = { kind: 'element', element: 'water', value: 1 };
+    const c3: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+    const s2 = advanceForbidden(s, [c1, c2]);
+    const s3 = advanceForbidden({ ...s2, phase: 'battle' }, [c2, c3]);
+    expect(s3.forbiddenCells).toHaveLength(2);
+  });
+});
+
+describe('advanceMovement', () => {
+  it('advances phase to revival', () => {
+    const s = stateWith([makeTeam(1 as NumberToken, fireWater)]);
+    const next = advanceMovement(s, 'fire', []);
+    expect(next.phase).toBe('revival');
+  });
+  it('moves team forward when card matches attribute', () => {
+    const team = makeTeam(1 as NumberToken, fireWater, 'east');
+    const s = stateWith([team]);
+    const card = {
+      kind: 'element' as const,
+      element: 'fire' as const,
+      value: 5 as const,
+    };
+    const next = advanceMovement(s, 'fire', [
+      { teamId: 1 as NumberToken, card, intendedFacing: 'east' },
+    ]);
+    const moved = next.grid['water']['water'];
+    expect(moved).toHaveLength(1);
+  });
+  it('rotates facing when card does not match attribute', () => {
+    const team = makeTeam(1 as NumberToken, fireWater, 'north');
+    const s = stateWith([team]);
+    const card = {
+      kind: 'element' as const,
+      element: 'water' as const,
+      value: 3 as const,
+    };
+    const next = advanceMovement(s, 'fire', [
+      { teamId: 1 as NumberToken, card, intendedFacing: 'south' },
+    ]);
+    const rotated = next.grid['fire']['water'];
+    expect(rotated[0]?.facing).toBe('south');
+  });
+  it('stays at grid edge when moving north from wood row', () => {
+    const team = makeTeam(1 as NumberToken, fireWood, 'north');
+    const s = stateWith([team]);
+    const card = {
+      kind: 'element' as const,
+      element: 'fire' as const,
+      value: 1 as const,
+    };
+    const next = advanceMovement(s, 'fire', [
+      { teamId: 1 as NumberToken, card, intendedFacing: 'north' },
+    ]);
+    const cell = next.grid['fire']['wood'];
+    expect(cell).toHaveLength(1);
+  });
+});
+
+describe('advanceRevival', () => {
+  it('advances phase to battle', () => {
+    const s = stateWith([]);
+    const next = advanceRevival({ ...s, phase: 'revival' });
+    expect(next.phase).toBe('battle');
+  });
+  it('increments round number', () => {
+    const s = stateWith([]);
+    const next = advanceRevival({ ...s, phase: 'revival' });
+    expect(next.round).toBe(s.round + 1);
+  });
+});

--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -1,0 +1,231 @@
+import type { Card, Element, ElementCard } from '../types/card.ts';
+import type {
+  ElementCoordinate,
+  Facing,
+  Grid,
+  GridCell,
+  GridCoord,
+  TeamState,
+} from '../types/grid.ts';
+import { ELEMENT_AXIS, isAdjacent, isSameCoord } from '../types/grid.ts';
+import type { NumberToken, TeamId } from '../types/token.ts';
+
+/** The four phases of a round, executed in order. */
+export type RoundPhase = 'battle' | 'forbidden' | 'movement' | 'revival';
+
+/** Immutable snapshot of the full game state at any point in a round. */
+export type RoundState = {
+  readonly phase: RoundPhase;
+  readonly round: number;
+  readonly grid: Grid;
+  /** All forbidden cells accumulated so far this game. */
+  readonly forbiddenCells: readonly GridCoord[];
+};
+
+/** One encounter result between two teams. */
+export type BattleResult = {
+  readonly teamA: TeamId;
+  readonly teamB: TeamId;
+  readonly encounterType: 'adjacent' | 'same-cell';
+};
+
+/** A team's movement card reveal during the movement phase. */
+export type TeamMove = {
+  readonly teamId: TeamId;
+  /** Card revealed for movement this round. */
+  readonly card: Card;
+  /** Facing the team chose when presenting the card (step 3 of movement). */
+  readonly intendedFacing: Facing;
+};
+
+/** Returns a blank 3×3 grid with no teams. */
+export function createEmptyGrid(): Grid {
+  const empty: GridCell = [];
+  const row = { fire: empty, water: empty, wood: empty } as const;
+  return { fire: row, water: row, wood: row } as Grid;
+}
+
+function allTeams(grid: Grid): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+function isTeamAlive(team: TeamState): boolean {
+  return team.players.some((p) => p.life > 0);
+}
+
+/**
+ * Returns BattleResult[] listing every pair of teams that encounter
+ * each other based on grid position (same cell or adjacent cells).
+ * Card resolution and damage are handled separately by the caller.
+ */
+export function advanceBattle(state: RoundState): BattleResult[] {
+  const teams = allTeams(state.grid);
+  const results: BattleResult[] = [];
+
+  for (let i = 0; i < teams.length; i++) {
+    for (let j = i + 1; j < teams.length; j++) {
+      const a = teams[i] as TeamState;
+      const b = teams[j] as TeamState;
+      if (isSameCoord(a.position, b.position)) {
+        results.push({
+          teamA: a.teamNumber,
+          teamB: b.teamNumber,
+          encounterType: 'same-cell',
+        });
+      } else if (isAdjacent(a.position, b.position)) {
+        results.push({
+          teamA: a.teamNumber,
+          teamB: b.teamNumber,
+          encounterType: 'adjacent',
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Advances from the battle phase to movement by recording the new
+ * forbidden cell. The first drawn card gives the x-coordinate and the
+ * second gives the y-coordinate.
+ */
+export function advanceForbidden(
+  state: RoundState,
+  drawnCards: readonly [ElementCard, ElementCard],
+): RoundState {
+  const newCell: GridCoord = {
+    x: drawnCards[0].element,
+    y: drawnCards[1].element,
+  };
+  return {
+    ...state,
+    phase: 'movement',
+    forbiddenCells: [...state.forbiddenCells, newCell],
+  };
+}
+
+function elementStep(
+  coord: ElementCoordinate,
+  delta: 1 | -1,
+): ElementCoordinate {
+  const idx = ELEMENT_AXIS.indexOf(coord);
+  const next = idx + delta;
+  if (next < 0 || next >= ELEMENT_AXIS.length) {
+    return coord;
+  }
+  return ELEMENT_AXIS[next] as ElementCoordinate;
+}
+
+function stepForward(pos: GridCoord, facing: Facing): GridCoord {
+  switch (facing) {
+    case 'north':
+      return { x: pos.x, y: elementStep(pos.y, 1) };
+    case 'south':
+      return { x: pos.x, y: elementStep(pos.y, -1) };
+    case 'east':
+      return { x: elementStep(pos.x, 1), y: pos.y };
+    case 'west':
+      return { x: elementStep(pos.x, -1), y: pos.y };
+  }
+}
+
+function replaceTeamInGrid(
+  grid: Grid,
+  oldPos: GridCoord,
+  updated: TeamState,
+): Grid {
+  const oldCell = grid[oldPos.x][oldPos.y].filter(
+    (t) => t.teamNumber !== updated.teamNumber,
+  );
+  const newPos = updated.position;
+  const prevNewCell =
+    oldPos.x === newPos.x && oldPos.y === newPos.y
+      ? oldCell
+      : grid[newPos.x][newPos.y];
+
+  const withOldRemoved = {
+    ...grid,
+    [oldPos.x]: { ...grid[oldPos.x], [oldPos.y]: oldCell },
+  } as Grid;
+
+  return {
+    ...withOldRemoved,
+    [newPos.x]: {
+      ...withOldRemoved[newPos.x],
+      [newPos.y]: [...prevNewCell, updated],
+    },
+  } as Grid;
+}
+
+function findTeam(grid: Grid, teamId: NumberToken): TeamState | undefined {
+  return allTeams(grid).find((t) => t.teamNumber === teamId);
+}
+
+/**
+ * Processes the movement phase. For each team that revealed a card:
+ * - If card element matches movementAttribute (or is a joker): move
+ *   the team one cell in its current facing direction.
+ * - Otherwise: update the team's facing to intendedFacing.
+ * Returns a new state with phase = 'revival'.
+ */
+export function advanceMovement(
+  state: RoundState,
+  movementAttribute: Element,
+  teamMoves: readonly TeamMove[],
+): RoundState {
+  let grid = state.grid;
+
+  for (const move of teamMoves) {
+    const team = findTeam(grid, move.teamId);
+    if (team === undefined) continue;
+
+    const cardElement = move.card.kind === 'element' ? move.card.element : null;
+    const isMove =
+      move.card.kind === 'joker' || cardElement === movementAttribute;
+
+    let updated: TeamState;
+    if (isMove) {
+      const newPos = stepForward(team.position, team.facing);
+      updated = { ...team, position: newPos };
+    } else {
+      updated = { ...team, facing: move.intendedFacing };
+    }
+
+    grid = replaceTeamInGrid(grid, team.position, updated);
+  }
+
+  return { ...state, phase: 'revival', grid };
+}
+
+/**
+ * Advances from revival to the next round's battle phase.
+ * Life-token recovery is not yet implemented (pending dropped-token
+ * tracking); this function only advances the round counter and phase.
+ */
+export function advanceRevival(state: RoundState): RoundState {
+  return { ...state, phase: 'battle', round: state.round + 1 };
+}
+
+/**
+ * Returns true when the game has ended: zero or one team still has at
+ * least one player with life remaining.
+ */
+export function isGameOver(state: RoundState): boolean {
+  return allTeams(state.grid).filter(isTeamAlive).length <= 1;
+}
+
+/**
+ * Returns the surviving team's ID when exactly one team is still alive,
+ * or null if the game is not yet over or ended in a draw.
+ */
+export function winner(state: RoundState): TeamId | null {
+  const alive = allTeams(state.grid).filter(isTeamAlive);
+  return alive.length === 1 ? (alive[0] as TeamState).teamNumber : null;
+}

--- a/packages/core/src/types/grid.ts
+++ b/packages/core/src/types/grid.ts
@@ -39,7 +39,11 @@ export type Grid = Readonly<
 >;
 
 /** Ordered axis positions: fire=0, water=1, wood=2. */
-const ELEMENT_AXIS: readonly ElementCoordinate[] = ['fire', 'water', 'wood'];
+export const ELEMENT_AXIS: readonly ElementCoordinate[] = [
+  'fire',
+  'water',
+  'wood',
+];
 
 /** Clockwise facing order. */
 const FACING_CW: readonly Facing[] = ['north', 'east', 'south', 'west'];


### PR DESCRIPTION
Closes #71

## Summary

- Add `RoundPhase`, `RoundState`, `BattleResult`, and `TeamMove` types in `src/logic/round.ts`
- `advanceBattle(state)`: identifies same-cell and adjacent team encounters; card resolution and damage delegated to caller
- `advanceForbidden(state, [cardX, cardY])`: records new forbidden cell, advances to movement phase
- `advanceMovement(state, attr, moves)`: moves teams forward when card matches movement attribute; rotates facing otherwise; clamps at grid edge
- `advanceRevival(state)`: advances to next round's battle phase (life-token recovery pending dropped-token tracking)
- `isGameOver` / `winner`: game ends when ≤1 team with living players
- Export `ELEMENT_AXIS` from `grid.ts` for use in round logic
- 21 tests covering all phase transitions, game-over detection, movement, and edge cases

## Test plan

- [x] `pnpm run test` — 73 tests pass (21 new)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)