### PR TITLE
feat(core): implement damage point calculation

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './config.ts';
+export * from './logic/damage.ts';
 export * from './logic/resolve.ts';
 export * from './logic/round.ts';
 export * from './types/card.ts';

--- a/packages/core/src/logic/damage.test.ts
+++ b/packages/core/src/logic/damage.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, ElementCard } from '../types/card.ts';
+import type { GridCoord, TeamState } from '../types/grid.ts';
+import type { LifeToken, NumberToken } from '../types/token.ts';
+import { calcDamage } from './damage.ts';
+
+function team(
+  id: NumberToken,
+  pos: GridCoord,
+  facing: TeamState['facing'],
+): TeamState {
+  return {
+    teamNumber: id,
+    position: pos,
+    facing,
+    cards: [],
+    players: [{ life: 4 as LifeToken }],
+  };
+}
+
+const fireWater: GridCoord = { x: 'fire', y: 'water' };
+const waterWater: GridCoord = { x: 'water', y: 'water' };
+const fireWood: GridCoord = { x: 'fire', y: 'wood' };
+
+const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+const fire1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
+const fire13: ElementCard = { kind: 'element', element: 'fire', value: 13 };
+const wood3: ElementCard = { kind: 'element', element: 'wood', value: 3 };
+const wood10: ElementCard = { kind: 'element', element: 'wood', value: 10 };
+const wood11: ElementCard = { kind: 'element', element: 'wood', value: 11 };
+const _water7: ElementCard = { kind: 'element', element: 'water', value: 7 };
+const joker: Card = { kind: 'joker' };
+
+const sameCellCtx = { encounterType: 'same-cell' as const };
+const adjacentCtx = { encounterType: 'adjacent' as const };
+
+describe('calcDamage — joker and absence wins', () => {
+  it('joker win always returns 1', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(calcDamage(w, l, joker, fire5, sameCellCtx)).toBe(1);
+  });
+  it('card-absence win returns 1', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(
+      calcDamage(w, l, fire5, wood3, { ...sameCellCtx, isAbsenceWin: true }),
+    ).toBe(1);
+  });
+});
+
+describe('calcDamage — facing bonus (same-cell)', () => {
+  it('adds 1 when facing are parallel (both north/south)', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(calcDamage(w, l, fire5, wood3, sameCellCtx)).toBe(2);
+  });
+  it('adds 1 when facing are parallel (both east/west)', () => {
+    const w = team(1 as NumberToken, fireWater, 'east');
+    const l = team(2 as NumberToken, fireWater, 'west');
+    expect(calcDamage(w, l, fire5, wood3, sameCellCtx)).toBe(2);
+  });
+  it('no bonus when perpendicular', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'east');
+    expect(calcDamage(w, l, fire5, wood3, sameCellCtx)).toBe(1);
+  });
+});
+
+describe('calcDamage — facing bonus (adjacent)', () => {
+  it('adds 1 when facing toward opponent and not perpendicular', () => {
+    const w = team(1 as NumberToken, fireWater, 'east'); // faces east toward waterWater
+    const l = team(2 as NumberToken, waterWater, 'west');
+    expect(calcDamage(w, l, fire5, wood3, adjacentCtx)).toBe(2);
+  });
+  it('no bonus when perpendicular even if facing toward', () => {
+    const w = team(1 as NumberToken, fireWater, 'east');
+    const l = team(2 as NumberToken, waterWater, 'north'); // perpendicular to east
+    expect(calcDamage(w, l, fire5, wood3, adjacentCtx)).toBe(1);
+  });
+  it('no bonus when not facing toward', () => {
+    const w = team(1 as NumberToken, fireWater, 'west'); // faces away from waterWater
+    const l = team(2 as NumberToken, waterWater, 'west');
+    expect(calcDamage(w, l, fire5, wood3, adjacentCtx)).toBe(1);
+  });
+  it('adjacent y-axis: north facing gives bonus', () => {
+    const w = team(1 as NumberToken, fireWater, 'north'); // water y=1 → wood y=2 is north
+    const l = team(2 as NumberToken, fireWood, 'south');
+    expect(calcDamage(w, l, fire5, wood3, adjacentCtx)).toBe(2);
+  });
+});
+
+describe('calcDamage — value modifier', () => {
+  it('bonus (+1) when winner value ≥ 2× loser', () => {
+    // fire5(5) vs wood3(3): 5 < 6, but fire13(13) vs wood3(3): 13 >= 6
+    const w = team(1 as NumberToken, fireWater, 'east');
+    const l = team(2 as NumberToken, waterWater, 'west');
+    expect(calcDamage(w, l, fire13, wood3, adjacentCtx)).toBe(3); // 1 base + 1 facing + 1 value
+  });
+  it('bonus (+1) when winner=13 and loser value 7–10', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(calcDamage(w, l, fire13, wood10, sameCellCtx)).toBe(3); // 1+1+1
+  });
+  it('bonus (+1) when winner≤2 and loser≥11', () => {
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(calcDamage(w, l, fire1, wood11, sameCellCtx)).toBe(3); // 1+1+1
+  });
+  it('penalty (−1) when loser value ≥ 2× winner', () => {
+    // fire5(5) winner vs wood11(11) loser: 11 >= 10 → penalty
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'south');
+    expect(calcDamage(w, l, fire5, wood11, sameCellCtx)).toBe(1); // 1+1-1=1
+  });
+  it('penalty reduces damage toward 0', () => {
+    // no facing bonus (perpendicular) + penalty = 1-1=0
+    const w = team(1 as NumberToken, fireWater, 'north');
+    const l = team(2 as NumberToken, fireWater, 'east'); // perpendicular → no facing bonus
+    expect(calcDamage(w, l, fire5, wood11, sameCellCtx)).toBe(0); // 1+0-1=0
+  });
+});

--- a/packages/core/src/logic/damage.ts
+++ b/packages/core/src/logic/damage.ts
@@ -1,0 +1,97 @@
+import type { Card, ElementCard } from '../types/card.ts';
+import { isElementCard, isJokerCard } from '../types/card.ts';
+import type { Facing, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS } from '../types/grid.ts';
+
+/** Context supplied by the caller to describe how the encounter was won. */
+export type DamageContext = {
+  readonly encounterType: 'adjacent' | 'same-cell';
+  /** True when the loser could not present a card (card-absence win). */
+  readonly isAbsenceWin?: boolean;
+};
+
+function axisIndex(coord: string): number {
+  return ELEMENT_AXIS.indexOf(coord as (typeof ELEMENT_AXIS)[number]);
+}
+
+function isPerpendicular(a: Facing, b: Facing): boolean {
+  const isNS = (f: Facing) => f === 'north' || f === 'south';
+  const isEW = (f: Facing) => f === 'east' || f === 'west';
+  return (isNS(a) && isEW(b)) || (isEW(a) && isNS(b));
+}
+
+function isFacingToward(winner: TeamState, loser: TeamState): boolean {
+  const dx = axisIndex(loser.position.x) - axisIndex(winner.position.x);
+  const dy = axisIndex(loser.position.y) - axisIndex(winner.position.y);
+  switch (winner.facing) {
+    case 'east':
+      return dx > 0;
+    case 'west':
+      return dx < 0;
+    case 'north':
+      return dy > 0;
+    case 'south':
+      return dy < 0;
+  }
+}
+
+function facingBonus(
+  winner: TeamState,
+  loser: TeamState,
+  encounterType: 'adjacent' | 'same-cell',
+): number {
+  const perp = isPerpendicular(winner.facing, loser.facing);
+  if (encounterType === 'same-cell') {
+    return perp ? 0 : 1;
+  }
+  return !perp && isFacingToward(winner, loser) ? 1 : 0;
+}
+
+function valueModifier(w: ElementCard, l: ElementCard): number {
+  const wv = w.value;
+  const lv = l.value;
+
+  if (
+    wv >= lv * 2 ||
+    (wv === 13 && lv >= 7 && lv <= 10) ||
+    (wv <= 2 && lv >= 11)
+  ) {
+    return 1;
+  }
+  if (
+    lv >= wv * 2 ||
+    (lv === 13 && wv >= 7 && wv <= 10) ||
+    (lv <= 2 && wv >= 11)
+  ) {
+    return -1;
+  }
+  return 0;
+}
+
+/**
+ * Calculates damage points dealt to the loser after an encounter.
+ * Returns 1 (fixed) for joker wins or card-absence wins.
+ * Otherwise: base 1 + facing bonus (0 or 1) + value modifier (−1, 0, or 1).
+ * Result is clamped to a minimum of 0.
+ */
+export function calcDamage(
+  winner: TeamState,
+  loser: TeamState,
+  winnerCard: Card,
+  loserCard: Card,
+  resolution: DamageContext,
+): number {
+  if (isJokerCard(winnerCard) || resolution.isAbsenceWin === true) {
+    return 1;
+  }
+
+  if (!isElementCard(winnerCard) || !isElementCard(loserCard)) {
+    return 1;
+  }
+
+  const base = 1;
+  const facing = facingBonus(winner, loser, resolution.encounterType);
+  const value = valueModifier(winnerCard, loserCard);
+
+  return Math.max(base + facing + value, 0);
+}


### PR DESCRIPTION
Closes #70

## Summary

- Add `calcDamage(winner, loser, winnerCard, loserCard, context)` in `src/logic/damage.ts`
- Base damage = 1; facing bonus +1 when non-perpendicular (same cell) or non-perpendicular + facing-toward (adjacent)
- Value modifier: +1 for ≥2× threshold / 13-vs-7–10 / ≤2-vs-≥11; −1 for inverse; clamped to min 0
- Joker wins and card-absence wins (`isAbsenceWin: true`) always return 1 (no bonus/penalty)
- Export `DamageContext` type from `src/index.ts`
- 14 Vitest tests covering all modifier combinations

## Test plan

- [x] `pnpm run test` — 92 tests pass (14 new)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)