### PR TITLE
feat(web): implement turn log component

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,4 +3,5 @@ export * from './logic/resolve.ts';
 export * from './logic/round.ts';
 export * from './types/card.ts';
 export * from './types/grid.ts';
+export * from './types/log.ts';
 export * from './types/token.ts';

--- a/packages/core/src/types/log.ts
+++ b/packages/core/src/types/log.ts
@@ -1,0 +1,8 @@
+import type { RoundPhase } from '../logic/round.ts';
+
+/** A single line in the game event history. */
+export type LogEntry = {
+  readonly round: number;
+  readonly phase: RoundPhase;
+  readonly message: string;
+};

--- a/packages/web/src/components/TurnLog.test.tsx
+++ b/packages/web/src/components/TurnLog.test.tsx
@@ -1,0 +1,39 @@
+import type { LogEntry } from '@kurone-kito/oneiron-core';
+import { cleanup, render, screen } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TurnLog } from './TurnLog.tsx';
+
+afterEach(cleanup);
+
+const entries: LogEntry[] = [
+  { round: 1, phase: 'battle', message: 'Team 1 vs Team 2' },
+  { round: 1, phase: 'movement', message: 'Team 1 moved' },
+  { round: 2, phase: 'battle', message: 'Team 3 vs Team 4' },
+];
+
+describe('TurnLog', () => {
+  it('renders without errors when entries is empty', () => {
+    render(() => <TurnLog entries={[]} />);
+    expect(screen.getByLabelText('Turn log')).toBeTruthy();
+  });
+
+  it('renders all entries', () => {
+    render(() => <TurnLog entries={entries} />);
+    expect(screen.getByText('Team 1 vs Team 2')).toBeTruthy();
+    expect(screen.getByText('Team 1 moved')).toBeTruthy();
+    expect(screen.getByText('Team 3 vs Team 4')).toBeTruthy();
+  });
+
+  it('renders newest entry first (reverse chronological)', () => {
+    render(() => <TurnLog entries={entries} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]?.textContent).toContain('Team 3 vs Team 4');
+    expect(items[items.length - 1]?.textContent).toContain('Team 1 vs Team 2');
+  });
+
+  it('shows round and phase labels', () => {
+    render(() => <TurnLog entries={[entries[0] as LogEntry]} />);
+    expect(screen.getByText('R1')).toBeTruthy();
+    expect(screen.getByText('battle')).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/TurnLog.tsx
+++ b/packages/web/src/components/TurnLog.tsx
@@ -1,0 +1,40 @@
+import type { LogEntry } from '@kurone-kito/oneiron-core';
+import { createEffect, createSignal, For } from 'solid-js';
+
+type Props = {
+  entries: LogEntry[];
+};
+
+export function TurnLog(props: Props) {
+  let listRef: HTMLOListElement | undefined;
+  const [prevLength, setPrevLength] = createSignal(props.entries.length);
+
+  createEffect(() => {
+    const current = props.entries.length;
+    if (current !== prevLength()) {
+      setPrevLength(current);
+      if (listRef?.firstElementChild) {
+        listRef.firstElementChild.scrollIntoView({ behavior: 'smooth' });
+      }
+    }
+  });
+
+  const sorted = () => [...props.entries].reverse();
+
+  return (
+    <section class="turn-log" aria-label="Turn log">
+      <h2 class="turn-log__title">Turn Log</h2>
+      <ol class="turn-log__list" ref={listRef}>
+        <For each={sorted()}>
+          {(entry) => (
+            <li class="turn-log__entry">
+              <span class="turn-log__round">R{entry.round}</span>
+              <span class="turn-log__phase">{entry.phase}</span>
+              <span class="turn-log__message">{entry.message}</span>
+            </li>
+          )}
+        </For>
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #75

## Summary

- Add `LogEntry` type (`{ round, phase, message }`) in `packages/core/src/types/log.ts`, re-exported from `src/index.ts`
- Add `TurnLog` Solid.js component in `packages/web/src/components/TurnLog.tsx`: renders entries in reverse-chronological order; auto-scrolls to newest on update
- 4 Vitest tests: empty array, all entries rendered, newest-first order, round/phase labels

## Test plan

- [x] `pnpm run test` — 82 tests pass (4 new)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Turn Log component displaying complete game event history with entries ordered newest-first
  * Each log entry shows round number and corresponding game phase label
  * Latest entries automatically scroll into view to keep focus on current game progress

* **Tests**
  * Added comprehensive test suite for Turn Log component including edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->