### PR TITLE
feat(web): implement grid rendering component

### DIFF
--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,4 +1,6 @@
-import type { Card } from '@kurone-kito/oneiron-core';
+import type { Card, Grid } from '@kurone-kito/oneiron-core';
+import { createEmptyGrid } from '@kurone-kito/oneiron-core';
+import { GameGrid } from './components/Grid.tsx';
 import { Hand } from './components/Hand.tsx';
 
 const demoCards: Card[] = [
@@ -7,12 +9,31 @@ const demoCards: Card[] = [
   { kind: 'joker' },
 ];
 
+const demoGrid: Grid = (() => {
+  const g = createEmptyGrid();
+  return {
+    ...g,
+    fire: {
+      ...g.fire,
+      water: [
+        {
+          teamNumber: 1,
+          position: { x: 'fire', y: 'water' },
+          facing: 'north',
+          cards: [],
+          players: [{ life: 3 }, { life: 4 }],
+        },
+      ],
+    },
+  } as Grid;
+})();
+
 export function App() {
   return (
     <main>
       <h1>⚔️ Dream Duels: The Battle for Oneiron</h1>
+      <GameGrid grid={demoGrid} forbiddenCells={[]} currentPhase="battle" />
       <Hand cards={demoCards} label="Demo Hand (face up)" faceUp={true} />
-      <Hand cards={demoCards} label="Demo Hand (face down)" faceUp={false} />
     </main>
   );
 }

--- a/packages/web/src/components/Grid.test.tsx
+++ b/packages/web/src/components/Grid.test.tsx
@@ -1,0 +1,64 @@
+import type { Grid, GridCoord, TeamState } from '@kurone-kito/oneiron-core';
+import { createEmptyGrid } from '@kurone-kito/oneiron-core';
+import { cleanup, render, screen } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GameGrid } from './Grid.tsx';
+
+afterEach(cleanup);
+
+const emptyGrid = createEmptyGrid();
+
+function gridWithTeam(team: TeamState): Grid {
+  const { x, y } = team.position;
+  return {
+    ...emptyGrid,
+    [x]: { ...emptyGrid[x], [y]: [team] },
+  } as Grid;
+}
+
+const team1: TeamState = {
+  teamNumber: 1,
+  position: { x: 'fire', y: 'water' },
+  facing: 'north',
+  cards: [],
+  players: [{ life: 3 }, { life: 2 }],
+};
+
+describe('GameGrid', () => {
+  it('renders a 3×3 grid with axis labels', () => {
+    render(() => (
+      <GameGrid grid={emptyGrid} forbiddenCells={[]} currentPhase="battle" />
+    ));
+    expect(screen.getAllByText('fire').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('water').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('wood').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders team position and facing arrow', () => {
+    const g = gridWithTeam(team1);
+    render(() => (
+      <GameGrid grid={g} forbiddenCells={[]} currentPhase="battle" />
+    ));
+    expect(screen.getByLabelText('Team 1')).toBeTruthy();
+    expect(screen.getByText('↑')).toBeTruthy();
+  });
+
+  it('marks forbidden cells with (forbidden) label', () => {
+    const forbidden: GridCoord[] = [{ x: 'fire', y: 'water' }];
+    render(() => (
+      <GameGrid
+        grid={emptyGrid}
+        forbiddenCells={forbidden}
+        currentPhase="forbidden"
+      />
+    ));
+    expect(screen.getByLabelText('fire,water (forbidden)')).toBeTruthy();
+  });
+
+  it('renders without errors when grid is empty', () => {
+    render(() => (
+      <GameGrid grid={emptyGrid} forbiddenCells={[]} currentPhase="revival" />
+    ));
+    expect(screen.getByLabelText('Game grid — revival phase')).toBeTruthy();
+  });
+});

--- a/packages/web/src/components/Grid.tsx
+++ b/packages/web/src/components/Grid.tsx
@@ -1,0 +1,89 @@
+import type {
+  Grid,
+  GridCoord,
+  RoundPhase,
+  TeamState,
+} from '@kurone-kito/oneiron-core';
+import { ELEMENT_AXIS } from '@kurone-kito/oneiron-core';
+import { For } from 'solid-js';
+
+const FACING_ARROW: Record<string, string> = {
+  north: '↑',
+  south: '↓',
+  east: '→',
+  west: '←',
+};
+
+type Props = {
+  grid: Grid;
+  forbiddenCells: GridCoord[];
+  currentPhase: RoundPhase;
+};
+
+function isForbidden(coord: GridCoord, forbidden: GridCoord[]): boolean {
+  return forbidden.some((c) => c.x === coord.x && c.y === coord.y);
+}
+
+function CellContent(props: { teams: readonly TeamState[] }) {
+  return (
+    <For each={props.teams}>
+      {(team) => (
+        <div
+          class="grid-cell__team"
+          role="img"
+          aria-label={`Team ${team.teamNumber}`}
+        >
+          <span class="grid-cell__token">{team.teamNumber}</span>
+          <span class="grid-cell__facing">{FACING_ARROW[team.facing]}</span>
+          <span class="grid-cell__life">
+            {team.players.reduce((s, p) => s + p.life, 0)}
+          </span>
+        </div>
+      )}
+    </For>
+  );
+}
+
+export function GameGrid(props: Props) {
+  return (
+    <section
+      class="game-grid"
+      aria-label={`Game grid — ${props.currentPhase} phase`}
+    >
+      <table class="game-grid__table">
+        <thead>
+          <tr>
+            <th class="game-grid__corner" />
+            <For each={[...ELEMENT_AXIS]}>
+              {(x) => <th class="game-grid__col-label">{x}</th>}
+            </For>
+          </tr>
+        </thead>
+        <tbody>
+          <For each={[...ELEMENT_AXIS]}>
+            {(y) => (
+              <tr>
+                <th class="game-grid__row-label">{y}</th>
+                <For each={[...ELEMENT_AXIS]}>
+                  {(x) => {
+                    const coord: GridCoord = { x, y };
+                    const forbidden = isForbidden(coord, props.forbiddenCells);
+                    const teams = props.grid[x][y];
+                    return (
+                      <td
+                        class={`game-grid__cell${forbidden ? ' game-grid__cell--forbidden' : ''}`}
+                        aria-label={`${x},${y}${forbidden ? ' (forbidden)' : ''}`}
+                      >
+                        <CellContent teams={teams} />
+                      </td>
+                    );
+                  }}
+                </For>
+              </tr>
+            )}
+          </For>
+        </tbody>
+      </table>
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #73

## Summary

- Add `GameGrid` Solid.js component in `packages/web/src/components/Grid.tsx`
- Renders a 3×3 `<table>` with fire/water/wood axis labels on rows and columns
- Each occupied cell shows: team number token, facing arrow (↑↓→←), total life across players
- Forbidden cells receive a `--forbidden` CSS modifier class and `(forbidden)` ARIA label
- Phase label displayed in section `aria-label` for screen readers
- Import and use in `App.tsx` with a demo team at (fire, water)
- 4 Vitest tests: axis labels, team rendering, forbidden overlay, empty grid

⚠️ Visual rendering was not verified in a browser (no GUI environment available).

## Test plan

- [x] `pnpm run test` — 100 tests pass (4 new)
- [x] `pnpm -r run typecheck` — no errors
- [x] `pnpm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)