### PR TITLE
chore(idd): re-import E/F-phase branch-sync refactor + external-check waiver flow

### DIFF
--- a/.cspell.config.yml
+++ b/.cspell.config.yml
@@ -7,6 +7,7 @@ import:
   - '@kurone-kito/cspell-config'
 version: '0.2'
 words:
+  - Esync
   - isort
   - oneiron
   - pylint

--- a/.github/instructions/idd-pre-merge.instructions.md
+++ b/.github/instructions/idd-pre-merge.instructions.md
@@ -1,8 +1,8 @@
 # IDD — Pre-Merge Conditions Phase (F1–F2)
 
-Read this file after ReviewItems_snapshot is empty (E3 or E8), or when
-returning to merge gate checks after a fix cycle. It covers final
-conflict resolution
+Read this file after the E-phase branch-sync check confirms no
+synchronization is required, or when returning to merge gate checks
+after a sync cycle. It covers a final read-only branch-state check
 (F1) and the full pre-merge condition checklist (F2).
 
 This phase includes a repository-specific GitHub Copilot advisory review
@@ -25,30 +25,32 @@ claim ownership, advisory wait, or CI gates.
 When all F2 conditions are satisfied, proceed to
 `idd-merge-handoff.instructions.md`.
 
-## F1 — Final conflict resolution
+## F1 — Final branch-state check
 
-Check whether the PR branch is out of date with `main` by running:
+Read the current branch state. When helper runtime is enabled, call:
+`idd-branch-conflict-state --pr {pr-number}`
+
+Otherwise read the state directly:
 
 ```sh
 gh pr view {pr-number} --json mergeable,mergeStateStatus
 ```
 
-If `mergeable` is `CONFLICTING` or `mergeStateStatus` is `BEHIND` or
-`DIRTY`, resolve conflicts:
+This check is read-only — F1 does not rebase, merge, or push.
 
-1. **Active review gate**: if the PR has unresolved review threads,
-   unreplied comments, or any reviewer's latest state is
-   `CHANGES_REQUESTED`, get explicit operator confirmation before
-   rebasing, as the history rewrite can disrupt ongoing review.
-2. Rebase onto `main`. Resolve any conflicts and continue the rebase.
-3. Run **post-fix-validate**.
-
-4. Push (use `--force-with-lease` if you rebased).
-5. If the HEAD changed (new commits were added): return to
-   `idd-review-snapshot.instructions.md` (E1) to re-evaluate reviews.
-   Before returning, update the PR live status digest with
-   `Phase: F1 rebased`, the new HEAD in `Authoritative by`, and
-   `Next action: E1 review snapshot`.
+- **`clean`** (`mergeable` is `MERGEABLE` and `mergeStateStatus` is
+  `CLEAN`) or **`behind-no-conflict`** when no up-to-date-head policy
+  applies: proceed to F2.
+- **`behind-no-conflict`** when branch protection or recorded repository
+  policy requires an up-to-date head, or **`content-conflict`**
+  (`mergeable` is `CONFLICTING`): return to the E-phase branch-sync check
+  in `idd-review-triage.instructions.md`. Before returning, update the PR
+  live status digest with `Phase: F1 sync-required`, the branch state in
+  `Open blockers`, and `Next action: E-phase branch-sync`.
+- **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
+  a PR comment documenting the branch state and stop. Do not proceed to F2
+  without confirmed clean branch-state evidence. A maintainer must clear
+  the hold.
 
 ## F2 — Pre-merge condition check
 
@@ -169,7 +171,23 @@ must align with every F2 condition below.
 - **CI**: Current PR head SHA has all required CI checks generated and
   all passing (→ run CI wait per `idd-ci.instructions.md` using the
   same resolved `ciWait.runningTimeout`, `ciWait.generationTimeout`, and
-  `ciWait.rerunPolicy` values; on-success → re-evaluate F2)
+  `ciWait.rerunPolicy` values; on-success → re-evaluate F2).
+
+  **External-check waivers**: When `pre-merge-readiness` reports a check
+  as `coveredByWaiver: true` in its output, a trusted maintainer has
+  authorized skipping that specific check under the current head SHA and
+  active claim. Treat it as passing for F2/F3 routing **only when**:
+  - `waiverEvidence.valid` is non-empty for that check's selector
+  - The waiver actor is a trusted marker login
+  - The waiver `headSha` matches the current PR HEAD
+  - The waiver `claimId` matches the active claim
+  - The waiver `expiresAt` is in the future
+
+  Waivers never bypass review currency, advisory wait, unresolved
+  threads, unreplied comments, required reviews, disposition evidence,
+  or claim ownership. If `waiverEvidence.wrongHead`, `wrongClaim`,
+  `unauthorized`, `expired`, or `malformed` are non-empty, report them
+  as suspicious context and do not treat them as valid permissions.
 - **Required reviews**: Required approvals count is satisfied and all
   CODEOWNER approvals are obtained. If helper evidence includes
   `reviewerStates.codeownerSelfApproval`, include that diagnostic in the

--- a/.github/instructions/idd-resume.instructions.md
+++ b/.github/instructions/idd-resume.instructions.md
@@ -128,7 +128,7 @@ Section numbers §W1–§W8 are detail entries in `docs/idd-resume-detail.md`.
 
 After routing, refresh the digest only when the route materially changes what
 a human should expect next (e.g., `Phase: resume → B3`, `Phase: resume → D1`,
-`Phase: resume → F1`). Set `Authoritative by` to the claim, PR/branch, CI,
+`Phase: resume → F2`). Set `Authoritative by` to the claim, PR/branch, CI,
 and review evidence used for the routing decision.
 
 ## Step 3 — Determine PR and CI/review state
@@ -142,7 +142,7 @@ node scripts/resume-route-selection.mjs --issue {issue-number}
 
 Map helper `route` to the Step 3 table outcomes:
 
-- `D1`, `D4`, `E1`, `E15`, `F1`, `F2` → matching row outcome.
+- `D1`, `D4`, `E1`, `E15`, `Esync`, `F1`, `F2` → matching row outcome.
 - `stop` → stop and report the helper reason; do not mutate state.
 
 Before any mutation after helper-assisted routing, still re-check live
@@ -159,7 +159,10 @@ output is invalid, use the written table below directly.
 | `failure` / `cancelled` / `timed_out` | no reviews                                                           | D4 failure/cancelled branch                        |
 | `failure` / `cancelled` / `timed_out` | reviews exist                                                        | E15 failure/cancelled branch                       |
 | `success`                             | unresolved threads / unreplied comments / active `CHANGES_REQUESTED` | → E1                                               |
-| `success`                             | none of the above                                                    | → F1                                               |
+| `success`                             | none of the above; branch clean                                      | → F2                                               |
+| `success`                             | none of the above; branch behind (no content conflict)               | → F1 (policy check, then F2 or Esync)              |
+| `success`                             | none of the above; branch has content conflict                       | → Esync (E-phase branch-sync check)                |
+| `success`                             | none of the above; branch dirty or unknown state                     | → hold/stop                                        |
 
 For forced-handoff recovery on an open PR: treat the final `success` row as
 → E1 until the successor has posted its own same-claim review watermark and

--- a/.github/instructions/idd-review-fix.instructions.md
+++ b/.github/instructions/idd-review-fix.instructions.md
@@ -54,19 +54,22 @@ Convergence guardrails:
 ## E11 — Resolve conflicts with main
 
 Check for conflicts between the feature branch and `main`. If conflicts
-exist, rebase the feature branch onto `main`, resolve any conflicts, and
-continue the rebase.
+exist, merge `main` into the feature branch
+(`git fetch origin main && git merge origin/main`), resolve any
+conflicts, and complete the merge.
 
 **Active review gate**: if the PR has unresolved review threads,
 unreplied comments, or any reviewer's latest state is
-`CHANGES_REQUESTED`, get explicit operator confirmation before rebasing,
-as the history rewrite can disrupt ongoing review.
+`CHANGES_REQUESTED`, get explicit operator confirmation before merging
+`main` into the feature branch, as the merge commit will appear in the
+PR history.
 
 ## E12 — Lint, test, push
 
 Run **post-fix-validate**.
 
-Then push with `--force-with-lease` (E11 uses rebase).
+Then push the feature branch normally (E11 uses merge commits, not
+rebase, so no force push is required).
 
 ## E13 — Reply to feedback
 

--- a/.github/instructions/idd-review-snapshot.instructions.md
+++ b/.github/instructions/idd-review-snapshot.instructions.md
@@ -8,7 +8,8 @@ Before posting any E-phase operational comment or GitHub reply, apply
 the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
-**If ReviewItems_snapshot is empty after E3**: proceed to `idd-pre-merge.instructions.md`.
+**If ReviewItems_snapshot is empty after E3**: proceed to the
+E-phase branch-sync check in `idd-review-triage.instructions.md`.
 **If ReviewItems_snapshot is non-empty after E3**: proceed to
 `idd-review-triage.instructions.md` (E4).
 
@@ -186,6 +187,7 @@ comment token; use the HTTP `POST` path for reliability).
 
 ## E3 — Empty list check
 
-If ReviewItems_snapshot is empty → proceed to `idd-pre-merge.instructions.md`.
+If ReviewItems_snapshot is empty → proceed to the E-phase branch-sync
+check in `idd-review-triage.instructions.md`.
 
 Otherwise → proceed to `idd-review-triage.instructions.md` (E4).

--- a/.github/instructions/idd-review-triage.instructions.md
+++ b/.github/instructions/idd-review-triage.instructions.md
@@ -9,7 +9,7 @@ the shared claim revalidation gate. The active claim must still use your
 current `{claim-id}`.
 
 **Skip condition E8**: if the Accepted PATH A count after verification
-is zero, proceed to `idd-pre-merge.instructions.md`.
+is zero, proceed to the **E-phase branch-sync check** below.
 
 ## E4 — Classify and score ReviewItems_snapshot
 
@@ -232,10 +232,55 @@ return to E1 afterward.
 
 ## E8 — Accepted PATH A count check
 
-If the Accepted PATH A count is zero → proceed to
-`idd-pre-merge.instructions.md`.
+If the Accepted PATH A count is zero → proceed to the
+**E-phase branch-sync check** below.
 
 Otherwise continue to `idd-review-fix.instructions.md`.
+
+## E-phase branch-sync check
+
+After the review loop confirms no PATH A items remain (from E3 or E8),
+check the current branch state before routing to F-phase. This gate uses
+merge-from-`main` (never rebase) when synchronization is required,
+preserving review history on the already-published PR branch.
+
+When helper runtime is enabled, call:
+`idd-branch-conflict-state --pr {pr-number}`
+
+Otherwise read branch state directly:
+
+```sh
+gh pr view {pr-number} --json mergeable,mergeStateStatus
+```
+
+Route based on `branchState` from the helper (or `mergeable` /
+`mergeStateStatus` from `gh pr view`):
+
+- **`clean`** or **`behind-no-conflict`** when branch protection does not
+  require an up-to-date head: proceed to
+  `idd-pre-merge.instructions.md` (F1).
+- **`behind-no-conflict`** when branch protection or recorded repository
+  policy requires an up-to-date head: → **sync path** below.
+- **`content-conflict`** (`mergeable` is `CONFLICTING`): → **sync path**
+  below.
+- **`dirty`** (`mergeStateStatus` is `DIRTY`) or **`unknown`**: hold; post
+  a PR comment documenting the state and stop. Do not proceed to F-phase
+  without confirmed branch-state evidence.
+
+**Sync path** (merge-from-`main`):
+
+1. **Active review gate**: if the PR has unresolved review threads,
+   unreplied comments, or any reviewer's latest state is
+   `CHANGES_REQUESTED`, get explicit operator confirmation before merging
+   `main` into the feature branch, as the merge commit will appear in the
+   PR history.
+2. Merge `main` into the feature branch:
+   `git fetch origin main && git merge origin/main`
+3. If conflicts arise, resolve them and complete the merge.
+4. Run **post-fix-validate**.
+5. Push the feature branch normally (no force push required for merge
+   commits).
+6. Return to `idd-review-snapshot.instructions.md` (E1).
 
 ## Review item classes
 

--- a/docs/idd-helper-scripts.md
+++ b/docs/idd-helper-scripts.md
@@ -36,6 +36,13 @@ In the idd-skill source repository, the following optional helpers were adopted:
   state routing (referenced in
   [kurone-kito/idd-skill#395](https://github.com/kurone-kito/idd-skill/issues/395))
 
+**Work & Submit Phase Helpers:**
+
+- `scripts/branch-conflict-state.mjs` for read-only branch conflict and
+  synchronization state classification; used by D/E/F routing to decide
+  whether `merge-main`, `hold-unknown`, or no action is needed without
+  mutating the worktree or PR branch (added in this release)
+
 **Review & Merge Phase Helpers:**
 
 - `scripts/review-activity-snapshot.mjs` for read-only E/F review
@@ -169,7 +176,8 @@ roadmap graph for one selected roadmap issue.
   - `edges`: `[{ source: number, target: number, relationship: string,`
     `evidence: string }]`
   - `provenancePaths`: `[{ target: number, path: number[] }]`
-  - `roadmapNodes`: `number[]`
+  - `roadmapNodes`: `number[]` — nested roadmap nodes discovered through
+    traversal; **excludes** the root roadmap (A1 traversal entry point)
   - `executionCandidates`: `number[]`
   - `diagnostics`: `{ duplicateReferences: object[], cycles: object[],`
     `inaccessibleReferences: object[], unresolvedReferences: object[] }`
@@ -348,8 +356,12 @@ The adopted helper boundaries are intentionally narrow:
 
 - `pre-merge-readiness.mjs` is read-only, emits machine-readable F2/F3
   evidence including review currency, unresolved-thread state,
-  unreplied comments, reviewer states, advisory state, CI, and claim
-  validation
+  unreplied comments, reviewer states, advisory state, CI, claim
+  validation, and `waiverEvidence` (parsed external-check waiver comments
+  classified as `valid`, `expired`, `wrongHead`, `wrongClaim`,
+  `unauthorized`, or `malformed`; checks covered by a valid waiver are
+  reported with `coveredByWaiver: true` and treated as passing by the CI
+  gate)
 - it does not replace the pre-merge or merge decision tables; it only
   reduces command-copy variance when collecting canonical merge-gate
   evidence
@@ -566,7 +578,7 @@ Interpretation rules:
 - Stable fields consumed by resume instructions: `route`, `reason`,
   `state`, and `evidence`
 - Stable enum:
-  - `route`: `D1|D4|E1|E15|F1|F2|stop`
+  - `route`: `D1|D4|E1|E15|Esync|F1|F2|stop`
 
 ### Advisory-wait evidence
 
@@ -683,6 +695,48 @@ Interpretation rules:
   fields are missing, or output conflicts with observed triage evidence,
   discard helper output and apply written E7 checks directly.
 
+### Branch conflict and synchronization state evidence
+
+- Preferred command when helper runtime is enabled:
+  `idd-branch-conflict-state --pr <pr-number>`
+- Source repository equivalent:
+  `node scripts/branch-conflict-state.mjs --pr <pr-number>`
+- Output schema (stable fields):
+
+  ```json
+  {
+    "protocolVersion": "1",
+    "prNumber": 123,
+    "prHeadSha": "abc...",
+    "prBaseSha": "def...",
+    "published": true,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "branchState": "clean",
+    "syncRecommendation": "none",
+    "readOnly": true,
+    "worktreeUnchanged": true,
+    "diagnostics": {
+      "mergeableSource": "github-mergeable",
+      "conflictFiles": [],
+      "notes": []
+    }
+  }
+  ```
+
+- `branchState` values: `clean`, `behind-no-conflict`, `content-conflict`,
+  `dirty`, `force-push-exception`, `unknown`
+- `syncRecommendation` values: `none`, `merge-main`, `policy-required-update`,
+  `force-push-exception`, `hold-unknown`
+- Stable fields consumed by D/E/F routing: `branchState`,
+  `syncRecommendation`, `published`, `readOnly`, `worktreeUnchanged`
+- Read-only boundary: the helper never runs `git merge`, `git rebase`, or
+  any command that leaves merge state, index changes, or working-tree
+  changes. The `readOnly` and `worktreeUnchanged` fields confirm this.
+- Fail closed: if execution fails, output is invalid JSON, or required
+  fields are missing, discard helper output and apply written D4/E-phase
+  branch-sync checks directly.
+
 ### S2 quiet-window evidence
 
 - When helper runtime is enabled, Resume/S2 should call the
@@ -720,6 +774,7 @@ The workflow areas most likely to benefit from optional helpers are:
 | Post-merge cleanup candidates   | Adopted helper     | Dry-run by default, explicit apply | High          | GraphQL minimize-comment fallback flow                                 | Medium — minimization safety still depends on exact review/marker rules                  | Medium — roughly 400 to 700 bytes of repeated GraphQL audit prose       |
 | E7 disposition verification     | Adopted helper     | Read-only evidence verifier        | Low           | E7 verification steps in `idd-review-triage.instructions.md`           | Low — verification logic is deterministic and path/type rules are stable                 | Low to medium — roughly 150 to 300 bytes of repeated E7 pre-exit checks |
 | Branch protection/ruleset reads | Deferred candidate | Read-only API adapter              | Low           | Direct ruleset / branch-protection API reads                           | Medium — repository support varies and incomplete coverage could create false confidence | Low to medium — roughly 150 to 300 bytes of repeated ruleset prose      |
+| Branch conflict state           | Adopted helper     | Read-only evidence collector       | Low           | D4/E-phase branch-sync checks in `idd-pr-submit.instructions.md`       | Medium — helper must stay evidence-only and preserve the written sync gates              | Medium — roughly 300 to 500 bytes of repeated branch-state prose        |
 
 ### Ranked roadmap candidate list for the source roadmap
 

--- a/docs/idd-workflow.md
+++ b/docs/idd-workflow.md
@@ -50,9 +50,9 @@ entry file should be an explicit operator choice, not the default.
 | `.github/instructions/idd-ci.instructions.md`              | D4/E15 helper: shared CI polling helper used by later phases                                                    |
 | `.github/instructions/idd-advisory-wait.instructions.md`   | AW1-AW5 helper: shared Copilot advisory-wait protocol (E14, F2, F3)                                             |
 | `.github/instructions/idd-review-snapshot.instructions.md` | E1–E3: fetch activity snapshot, run critique, check if ReviewItems_snapshot is empty                            |
-| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, and record dispositions                                                           |
-| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits                                                    |
-| `.github/instructions/idd-pre-merge.instructions.md`       | F1–F2: resolve conflicts and verify all pre-merge conditions                                                    |
+| `.github/instructions/idd-review-triage.instructions.md`   | E4–E8: classify items, score, record dispositions, and run E-phase branch-sync check before F-phase             |
+| `.github/instructions/idd-review-fix.instructions.md`      | E9-E15: fix accepted review items and push follow-up commits (merge-from-main, not rebase)                      |
+| `.github/instructions/idd-pre-merge.instructions.md`       | F1: final read-only branch-state check; F2: verify all pre-merge conditions                                     |
 | `.github/instructions/idd-merge-handoff.instructions.md`   | F2.5: resolve merge-policy handoff vs autonomous merge routing                                                  |
 | `.github/instructions/idd-merge.instructions.md`           | F3–F5: execute the merge, clean up, and loop back to discover                                                   |
 | `.github/instructions/idd-resume.instructions.md`          | Resume Step 0-3: route crash, stalled, stale-takeover, or clean continuation                                    |


### PR DESCRIPTION
Closes #94
Refs roadmap #93

## Summary

- **E-phase branch-sync check** (new section in `idd-review-triage.md`): run after PATH-A items are cleared, before F-phase. Uses `merge from main` (never rebase) to preserve PR history.
- **F1 becomes read-only** (`idd-pre-merge.md`): checks branch state via `branch-conflict-state` helper; routes back to E-phase if sync needed.
- **F2 external-check waivers** (`idd-pre-merge.md`): `coveredByWaiver: true` checks treated as passing only when `waiverEvidence.valid` is non-empty AND actor is trusted AND `headSha`/`claimId` match AND `expiresAt` is future. Waivers never bypass review currency, advisory wait, or claim ownership.
- **Routing updates**: `review-fix.md` uses `merge origin/main` (no force-push for non-rebase flow); `review-snapshot.md` routes empty snapshot to E-phase branch-sync; `resume.md` adds `Esync` row to the routing table.
- **Docs**: `idd-workflow.md` table rows updated; `idd-helper-scripts.md` documents the `branch-conflict-state` helper schema and `waiverEvidence` reporting on `pre-merge-readiness`.
- **Cspell**: adds `Esync` to wordlist.

Preserves all oneiron placeholder substitutions (no `{{...}}` leaks).

## Test plan

- [x] `pnpm run lint` — biome, markdown, cspell all clean (no errors)
- [x] Placeholder leak check on changed files — clean
- [x] Spot-checked key sections render in correct context (review-triage E-phase branch-sync, pre-merge F2 waiver logic, resume Esync routing table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal workflow instructions to refine merge and branch synchronization processes.
  * Enhanced helper script documentation to clarify validation criteria and routing logic.
  * Clarified pre-merge and review-phase guidance for improved workflow clarity.

* **Chores**
  * Updated spell-checking configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->