### PR TITLE
chore(idd): re-import A2 roadmap-node classifier + bundle-discovery limit

### DIFF
--- a/.github/instructions/idd-discover.instructions.md
+++ b/.github/instructions/idd-discover.instructions.md
@@ -257,6 +257,9 @@ traversal-only coordination nodes:
   A3/A4/A4.5/A5.
 - Track open roadmap nodes separately and report them alongside the A2
   execution candidates.
+- The root roadmap selected by A1 is the traversal starting point and
+  is not added to the roadmap-node set; only issues discovered through
+  its outbound references are classified and reported.
 
 **Permitted repo-wide queries** — only the following scoped lookups may
 touch issues outside the roadmap traversal graph:

--- a/docs/policy-constants.md
+++ b/docs/policy-constants.md
@@ -273,7 +273,7 @@ CI enforces two layers of instruction file size limits via `audit/sync-manifest.
 
 | Bundle ID          | Files included                                                                                   | Limit        |
 | ------------------ | ------------------------------------------------------------------------------------------------ | ------------ |
-| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,200 bytes |
+| `bundle-discovery` | `idd-overview-core` + `idd-overview-appendix` + `idd-discover` + `idd-suitability` + `idd-claim` | 75,300 bytes |
 | `bundle-resume`    | `idd-overview-core` + `idd-overview-appendix` + `idd-resume`                                     | 46,000 bytes |
 
 Bundle checks run unconditionally (not filtered by changed files) and


### PR DESCRIPTION
Closes #95
Refs roadmap #93

## Summary

- **`idd-discover.instructions.md`**: A2 traversal note that the root roadmap selected by A1 is the traversal starting point and is **not** added to the roadmap-node set; only issues discovered through its outbound references are classified and reported.
- **`docs/policy-constants.md`**: `bundle-discovery` byte-limit raised from 75,200 → 75,300 to accommodate the slightly larger discover bundle after the A2 classifier addition.

Preserves all oneiron placeholder substitutions.

## Test plan

- [x] `pnpm run lint` — biome, markdown, cspell all clean (no errors)
- [x] Placeholder leak check — clean
- [x] Diff verified: 4 insertions, 1 deletion across exactly 2 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified root roadmap behavior in discovery process to specify it serves as a starting point only
  * Updated instruction bundle byte limit from 75,200 to 75,300 bytes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->