### PR TITLE
feat(core): implement battle phase encounter ordering and damage application

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './config.ts';
+export * from './logic/battle.ts';
 export * from './logic/damage.ts';
 export * from './logic/resolve.ts';
 export * from './logic/round.ts';

--- a/packages/core/src/logic/battle.test.ts
+++ b/packages/core/src/logic/battle.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from 'vitest';
+import type { Card, ElementCard, JokerCard } from '../types/card.ts';
+import type { Facing, Grid, GridCoord, TeamState } from '../types/grid.ts';
+import type { NumberToken } from '../types/token.ts';
+import { createLifeToken } from '../types/token.ts';
+import type { BattlePlay } from './battle.ts';
+import { orderEncounters, resolveBattlePhase } from './battle.ts';
+import type { RoundState } from './round.ts';
+import { createEmptyGrid } from './round.ts';
+
+const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+const fire9: ElementCard = { kind: 'element', element: 'fire', value: 9 };
+const fire13: ElementCard = { kind: 'element', element: 'fire', value: 13 };
+const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+const water7: ElementCard = { kind: 'element', element: 'water', value: 7 };
+const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+const wood4: ElementCard = { kind: 'element', element: 'wood', value: 4 };
+const wood12: ElementCard = { kind: 'element', element: 'wood', value: 12 };
+const joker: JokerCard = { kind: 'joker' };
+
+function makeTeam(opts: {
+  id: NumberToken;
+  position: GridCoord;
+  facing?: Facing;
+  life?: number;
+  members?: 1 | 2;
+  gridCards?: readonly [Card, Card];
+}): TeamState {
+  const facing = opts.facing ?? 'north';
+  const life = opts.life ?? 2;
+  const members = opts.members ?? 2;
+  const players =
+    members === 1
+      ? [{ life: createLifeToken(life) }]
+      : [{ life: createLifeToken(life) }, { life: createLifeToken(life) }];
+  return {
+    teamNumber: opts.id,
+    position: opts.position,
+    facing,
+    cards: [],
+    players,
+    ...(opts.gridCards ? { gridCards: opts.gridCards } : {}),
+  };
+}
+
+function stateWith(teams: readonly TeamState[]): RoundState {
+  let grid: Grid = createEmptyGrid();
+  for (const team of teams) {
+    const { x, y } = team.position;
+    grid = {
+      ...grid,
+      [x]: { ...grid[x], [y]: [...grid[x][y], team] },
+    } as Grid;
+  }
+  return { phase: 'battle', round: 1, grid, forbiddenCells: [] };
+}
+
+const fireWater: GridCoord = { x: 'fire', y: 'water' };
+const waterWater: GridCoord = { x: 'water', y: 'water' };
+const woodWater: GridCoord = { x: 'wood', y: 'water' };
+const fireFire: GridCoord = { x: 'fire', y: 'fire' };
+const _fireWood: GridCoord = { x: 'fire', y: 'wood' };
+
+describe('orderEncounters', () => {
+  it('returns no encounters when teams are far apart', () => {
+    const s = stateWith([
+      makeTeam({ id: 1 as NumberToken, position: fireFire }),
+      makeTeam({ id: 2 as NumberToken, position: woodWater }),
+    ]);
+    expect(orderEncounters(s)).toEqual([]);
+  });
+
+  it('returns single same-cell encounter for 2 teams in same cell', () => {
+    const s = stateWith([
+      makeTeam({ id: 1 as NumberToken, position: fireWater }),
+      makeTeam({ id: 2 as NumberToken, position: fireWater }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    expect(enc[0]?.encounterType).toBe('same-cell');
+  });
+
+  it('pairs the lowest pair-sums first in same-cell with 4 teams', () => {
+    // Team A pair-sum = 5+3 = 8
+    // Team B pair-sum = 9+12 = 21
+    // Team C pair-sum = 1+4 = 5
+    // Team D pair-sum = 7+1 = 8
+    // Sorted ascending by pair-sum (teamNumber tiebreaker):
+    //   C(5), A(8), D(8), B(21)
+    // Pairs: (C, A) and (D, B)
+    const s = stateWith([
+      makeTeam({
+        id: 1 as NumberToken,
+        position: fireWater,
+        gridCards: [fire5, water3],
+      }),
+      makeTeam({
+        id: 2 as NumberToken,
+        position: fireWater,
+        gridCards: [fire9, wood12],
+      }),
+      makeTeam({
+        id: 3 as NumberToken,
+        position: fireWater,
+        gridCards: [wood1, wood4],
+      }),
+      makeTeam({
+        id: 4 as NumberToken,
+        position: fireWater,
+        gridCards: [water7, wood1],
+      }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(2);
+    const pairs = enc.map((e) => `${e.teamA}-${e.teamB}`).sort();
+    expect(pairs).toContain('3-1');
+    expect(pairs).toContain('4-2');
+  });
+
+  it('skips the odd team out when 3 teams share a cell', () => {
+    // Team 1 pair-sum = 5+3 = 8
+    // Team 2 pair-sum = 1+1 = 2 (lowest)
+    // Team 3 pair-sum = 9+12 = 21
+    // Sorted: T2(2), T1(8), T3(21)
+    // Pair: (T2, T1), T3 skipped
+    const s = stateWith([
+      makeTeam({
+        id: 1 as NumberToken,
+        position: fireWater,
+        gridCards: [fire5, water3],
+      }),
+      makeTeam({
+        id: 2 as NumberToken,
+        position: fireWater,
+        gridCards: [wood1, wood1],
+      }),
+      makeTeam({
+        id: 3 as NumberToken,
+        position: fireWater,
+        gridCards: [fire9, wood12],
+      }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    expect(enc[0]?.teamA).toBe(2);
+    expect(enc[0]?.teamB).toBe(1);
+  });
+
+  it('treats joker as pair value 25', () => {
+    // Team 1 pair-sum = joker(25) + joker(25) = 50
+    // Team 2 pair-sum = fire5 + water3 = 8 (lowest)
+    // Pair: (T2 first, T1 second) → (T2, T1)
+    const s = stateWith([
+      makeTeam({
+        id: 1 as NumberToken,
+        position: fireWater,
+        gridCards: [joker, joker],
+      }),
+      makeTeam({
+        id: 2 as NumberToken,
+        position: fireWater,
+        gridCards: [fire5, water3],
+      }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    expect(enc[0]?.teamA).toBe(2);
+    expect(enc[0]?.teamB).toBe(1);
+  });
+
+  it('returns adjacent encounters when no same-cell encounter applies', () => {
+    const s = stateWith([
+      makeTeam({ id: 1 as NumberToken, position: fireWater }),
+      makeTeam({ id: 2 as NumberToken, position: waterWater }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    expect(enc[0]?.encounterType).toBe('adjacent');
+  });
+
+  it('does not list adjacent encounter when teams already encountered same-cell', () => {
+    // Team 1 and Team 2 same cell. Team 3 adjacent to both.
+    // Team 1+2 encounter same-cell; Team 3 has no remaining partner.
+    const s = stateWith([
+      makeTeam({
+        id: 1 as NumberToken,
+        position: fireWater,
+        gridCards: [fire5, water3],
+      }),
+      makeTeam({
+        id: 2 as NumberToken,
+        position: fireWater,
+        gridCards: [wood1, wood4],
+      }),
+      makeTeam({
+        id: 3 as NumberToken,
+        position: waterWater,
+        gridCards: [fire5, fire5],
+      }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    expect(enc[0]?.encounterType).toBe('same-cell');
+  });
+
+  it('falls back to teamNumber order when gridCards undefined', () => {
+    const s = stateWith([
+      makeTeam({ id: 5 as NumberToken, position: fireWater }),
+      makeTeam({ id: 2 as NumberToken, position: fireWater }),
+    ]);
+    const enc = orderEncounters(s);
+    expect(enc).toHaveLength(1);
+    // Team 2 (sum=4) before Team 5 (sum=10) in fallback ordering
+    expect(enc[0]?.teamA).toBe(2);
+    expect(enc[0]?.teamB).toBe(5);
+  });
+});
+
+describe('resolveBattlePhase', () => {
+  function play(teamId: NumberToken, card: Card | null): BattlePlay {
+    return { teamId, card };
+  }
+
+  it('returns no results when no encounters', () => {
+    const s = stateWith([
+      makeTeam({ id: 1 as NumberToken, position: fireFire }),
+      makeTeam({ id: 2 as NumberToken, position: woodWater }),
+    ]);
+    const out = resolveBattlePhase(s, []);
+    expect(out.results).toEqual([]);
+  });
+
+  it('applies damage to loser via calcDamage', () => {
+    // Same-cell, north vs south (parallel) → facing bonus +1
+    // fire5 vs wood4 → fire wins by RPS; values 5 vs 4 → no value modifier
+    // Damage = 1 base + 1 facing = 2
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood4),
+    ]);
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]?.winner).toBe(1);
+    expect(out.results[0]?.damage).toBe(2);
+    // Loser at fireWater coord has 2 dropped tokens
+    expect(out.state.droppedLifeTokens?.fire.water).toBe(2);
+    // Team B life reduced from 4 to 2
+    const newB = out.state.grid.fire.water.find((t) => t.teamNumber === 2);
+    expect(newB?.players[0]?.life).toBe(2);
+  });
+
+  it('joker win → fixed damage 1', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [joker, joker],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, joker),
+      play(2 as NumberToken, fire5),
+    ]);
+    expect(out.results[0]?.winner).toBe(1);
+    expect(out.results[0]?.damage).toBe(1);
+  });
+
+  it('both teams forfeit (null cards) → draw, no damage', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, null),
+      play(2 as NumberToken, null),
+    ]);
+    expect(out.results[0]?.winner).toBeNull();
+    expect(out.results[0]?.damage).toBe(0);
+  });
+
+  it('card-holder beats card-absence with fixed damage 1', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, null),
+    ]);
+    expect(out.results[0]?.winner).toBe(1);
+    expect(out.results[0]?.damage).toBe(1);
+  });
+
+  it('eliminates a team when all players reach life 0', () => {
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 1,
+      members: 1,
+      gridCards: [wood1, wood4],
+    });
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const s = stateWith([winnerTeam, loser]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood1),
+    ]);
+    expect(out.results[0]?.winner).toBe(1);
+    // Loser had 1 life; damage ≥ 1 eliminates them.
+    const losers = out.state.grid.fire.water.filter((t) => t.teamNumber === 2);
+    expect(losers).toHaveLength(0);
+    // Only 1 token actually dropped (loser's remaining life)
+    expect(out.state.droppedLifeTokens?.fire.water).toBe(1);
+  });
+
+  it('draw (same element) does not change state', () => {
+    const a = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const b = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([a, b]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, fire9),
+    ]);
+    expect(out.results[0]?.winner).toBeNull();
+    expect(out.results[0]?.damage).toBe(0);
+    expect(out.state.droppedLifeTokens?.fire.water).toBe(0);
+  });
+
+  it('damage to multi-player team hits lowest-life player first', () => {
+    // 2-player team: lives [1, 4]. Damage 2 → player 0 to 0 first, then player 1 to 3.
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire13, water3],
+    });
+    const teamB: TeamState = {
+      teamNumber: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      cards: [],
+      players: [{ life: createLifeToken(1) }, { life: createLifeToken(4) }],
+      gridCards: [wood1, wood4],
+    };
+    const s = stateWith([teamA, teamB]);
+    // fire13 vs wood1: fire wins. Damage = 1 base + 1 facing + 1 bonus = 3
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire13),
+      play(2 as NumberToken, wood1),
+    ]);
+    expect(out.results[0]?.damage).toBe(3);
+    const newB = out.state.grid.fire.water.find((t) => t.teamNumber === 2);
+    // 3 damage hits: lowest=p0(1)→0, then lowest-alive=p1(4)→3, then→2
+    expect(newB?.players[0]?.life).toBe(0);
+    expect(newB?.players[1]?.life).toBe(2);
+    expect(out.state.droppedLifeTokens?.fire.water).toBe(3);
+  });
+
+  it('subsequent encounters operate on updated state', () => {
+    // 3 teams: 1 & 2 same-cell, 3 also same-cell
+    // Sorted by pair-sum: assume team 1 lowest, then team 2, then team 3
+    // Round 1 encounter: pairs (T1, T2)
+    // T3 skipped this round
+    const a = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood1],
+    });
+    const b = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+    });
+    const c = makeTeam({
+      id: 3 as NumberToken,
+      position: fireWater,
+      facing: 'east',
+      life: 4,
+      members: 1,
+      gridCards: [fire13, wood12],
+    });
+    const s = stateWith([a, b, c]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, wood1),
+      play(2 as NumberToken, fire5),
+      play(3 as NumberToken, fire5),
+    ]);
+    // Only 1 encounter pair this round
+    expect(out.results).toHaveLength(1);
+  });
+});

--- a/packages/core/src/logic/battle.ts
+++ b/packages/core/src/logic/battle.ts
@@ -1,0 +1,277 @@
+import type { Card } from '../types/card.ts';
+import type { Grid, GridCoord, PlayerState, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS, isAdjacent, isSameCoord } from '../types/grid.ts';
+import type { TeamId } from '../types/token.ts';
+import { createLifeToken } from '../types/token.ts';
+import { calcDamage } from './damage.ts';
+import { resolveCards } from './resolve.ts';
+import type {
+  BattleResult,
+  DroppedTokens,
+  EncounterPair,
+  RoundState,
+} from './round.ts';
+import { createEmptyDroppedTokens } from './round.ts';
+
+/** The card a team played for this battle phase. Null = no card. */
+export type BattlePlay = {
+  readonly teamId: TeamId;
+  readonly card: Card | null;
+};
+
+/** Joker counts as 25 for pair-sum ordering, per rules.ja.md §Battle 1. */
+const JOKER_PAIR_VALUE = 25;
+
+function cardValueForOrdering(card: Card): number {
+  return card.kind === 'joker' ? JOKER_PAIR_VALUE : card.value;
+}
+
+/**
+ * Pair-sum used for encounter ordering. Sums the two cards under the
+ * team's number token. If `gridCards` is missing (legacy state),
+ * falls back to `teamNumber * 2` to preserve deterministic order.
+ */
+function pairSum(team: TeamState): number {
+  const cards = team.gridCards;
+  if (cards === undefined) return team.teamNumber * 2;
+  const [a, b] = cards;
+  return cardValueForOrdering(a) + cardValueForOrdering(b);
+}
+
+function allTeams(grid: Grid): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+/**
+ * Orders this round's encounters per rules.ja.md §Battle 1:
+ * - Same-cell pairs first, ordered by ascending pair-sum. With more
+ *   than two teams on a cell, pair the lowest-sum pairs; remaining
+ *   teams (odd count) are "next in line" and skip the round.
+ * - Adjacent pairs collected only for teams that did not encounter
+ *   in the same-cell pass.
+ * - Each team participates in at most one encounter per round.
+ */
+export function orderEncounters(state: RoundState): readonly EncounterPair[] {
+  const teams = allTeams(state.grid);
+  const results: EncounterPair[] = [];
+  const encountered = new Set<TeamId>();
+
+  // Group teams by coordinate for same-cell pass.
+  const byCoord = new Map<string, TeamState[]>();
+  for (const team of teams) {
+    const key = `${team.position.x},${team.position.y}`;
+    const list = byCoord.get(key) ?? [];
+    list.push(team);
+    byCoord.set(key, list);
+  }
+
+  for (const list of byCoord.values()) {
+    if (list.length < 2) continue;
+    const sorted = [...list].sort((a, b) => {
+      const ps = pairSum(a) - pairSum(b);
+      if (ps !== 0) return ps;
+      return a.teamNumber - b.teamNumber;
+    });
+    for (let i = 0; i + 1 < sorted.length; i += 2) {
+      const a = sorted[i] as TeamState;
+      const b = sorted[i + 1] as TeamState;
+      results.push({
+        teamA: a.teamNumber,
+        teamB: b.teamNumber,
+        encounterType: 'same-cell',
+      });
+      encountered.add(a.teamNumber);
+      encountered.add(b.teamNumber);
+    }
+  }
+
+  // Adjacent pass: only teams not yet in an encounter.
+  for (let i = 0; i < teams.length; i++) {
+    const a = teams[i] as TeamState;
+    if (encountered.has(a.teamNumber)) continue;
+    for (let j = i + 1; j < teams.length; j++) {
+      const b = teams[j] as TeamState;
+      if (encountered.has(b.teamNumber)) continue;
+      if (isSameCoord(a.position, b.position)) continue;
+      if (isAdjacent(a.position, b.position)) {
+        results.push({
+          teamA: a.teamNumber,
+          teamB: b.teamNumber,
+          encounterType: 'adjacent',
+        });
+        encountered.add(a.teamNumber);
+        encountered.add(b.teamNumber);
+        break;
+      }
+    }
+  }
+
+  return results;
+}
+
+function isTeamDead(team: TeamState): boolean {
+  return team.players.every((p) => p.life === 0);
+}
+
+/**
+ * Applies `damage` to the team by removing one life token at a time
+ * from the lowest-life living player. Returns the updated team and
+ * the actual number of tokens removed (may be less than `damage`
+ * when all players have already reached 0).
+ */
+function applyDamage(
+  team: TeamState,
+  damage: number,
+): { team: TeamState; tokensDropped: number } {
+  const players: PlayerState[] = team.players.map((p) => ({ life: p.life }));
+  let tokensDropped = 0;
+  for (let i = 0; i < damage; i++) {
+    let lowestIdx = -1;
+    let lowestLife = Number.POSITIVE_INFINITY;
+    for (let j = 0; j < players.length; j++) {
+      const p = players[j] as PlayerState;
+      if (p.life > 0 && p.life < lowestLife) {
+        lowestLife = p.life;
+        lowestIdx = j;
+      }
+    }
+    if (lowestIdx === -1) break;
+    const p = players[lowestIdx] as PlayerState;
+    players[lowestIdx] = { life: createLifeToken(p.life - 1) };
+    tokensDropped += 1;
+  }
+  return { team: { ...team, players }, tokensDropped };
+}
+
+function addDroppedTokens(
+  tokens: DroppedTokens,
+  coord: GridCoord,
+  delta: number,
+): DroppedTokens {
+  const current = tokens[coord.x][coord.y];
+  return {
+    ...tokens,
+    [coord.x]: { ...tokens[coord.x], [coord.y]: current + delta },
+  } as DroppedTokens;
+}
+
+function findTeam(grid: Grid, teamId: TeamId): TeamState | undefined {
+  return allTeams(grid).find((t) => t.teamNumber === teamId);
+}
+
+function removeTeamFromGrid(grid: Grid, team: TeamState): Grid {
+  const { x, y } = team.position;
+  const cell = grid[x][y].filter((t) => t.teamNumber !== team.teamNumber);
+  return {
+    ...grid,
+    [x]: { ...grid[x], [y]: cell },
+  } as Grid;
+}
+
+function updateTeamInGrid(grid: Grid, updated: TeamState): Grid {
+  const { x, y } = updated.position;
+  const cell = grid[x][y].map((t) =>
+    t.teamNumber === updated.teamNumber ? updated : t,
+  );
+  return {
+    ...grid,
+    [x]: { ...grid[x], [y]: cell },
+  } as Grid;
+}
+
+/**
+ * Resolves the battle phase end-to-end:
+ * - Compute encounter order via {@link orderEncounters}.
+ * - For each encounter pair, take the played card (or `null` for
+ *   card absence), determine the winner via `resolveCards`, compute
+ *   damage via `calcDamage` (joker/absence → fixed 1), then apply
+ *   damage to the loser, drop tokens at the loser's coordinate, and
+ *   remove the team from the grid when all players are eliminated.
+ * - Returns the updated state (with a refreshed `droppedLifeTokens`
+ *   map) and the full enriched `BattleResult[]`.
+ */
+export function resolveBattlePhase(
+  state: RoundState,
+  plays: readonly BattlePlay[],
+): { readonly state: RoundState; readonly results: readonly BattleResult[] } {
+  const encounters = orderEncounters(state);
+  const playMap = new Map<TeamId, Card | null>();
+  for (const play of plays) {
+    playMap.set(play.teamId, play.card);
+  }
+
+  let grid = state.grid;
+  let droppedLifeTokens = state.droppedLifeTokens ?? createEmptyDroppedTokens();
+  const results: BattleResult[] = [];
+
+  for (const enc of encounters) {
+    const teamA = findTeam(grid, enc.teamA);
+    const teamB = findTeam(grid, enc.teamB);
+    if (teamA === undefined || teamB === undefined) {
+      results.push({ ...enc, winner: null, damage: 0 });
+      continue;
+    }
+
+    const cardA = playMap.has(enc.teamA)
+      ? (playMap.get(enc.teamA) as Card | null)
+      : null;
+    const cardB = playMap.has(enc.teamB)
+      ? (playMap.get(enc.teamB) as Card | null)
+      : null;
+
+    let winnerId: TeamId | null = null;
+    let damage = 0;
+
+    if (cardA === null && cardB === null) {
+      // Both forfeit → draw.
+    } else if (cardA === null) {
+      winnerId = enc.teamB;
+      damage = 1;
+    } else if (cardB === null) {
+      winnerId = enc.teamA;
+      damage = 1;
+    } else {
+      const outcome = resolveCards(cardA, cardB);
+      if (outcome === 'a') {
+        winnerId = enc.teamA;
+        damage = calcDamage(teamA, teamB, cardA, cardB, {
+          encounterType: enc.encounterType,
+        });
+      } else if (outcome === 'b') {
+        winnerId = enc.teamB;
+        damage = calcDamage(teamB, teamA, cardB, cardA, {
+          encounterType: enc.encounterType,
+        });
+      }
+      // outcome === 'draw' → winner null, damage 0
+    }
+
+    results.push({ ...enc, winner: winnerId, damage });
+
+    if (winnerId === null || damage <= 0) continue;
+
+    const loser = winnerId === enc.teamA ? teamB : teamA;
+    const { team: damagedLoser, tokensDropped } = applyDamage(loser, damage);
+
+    droppedLifeTokens = addDroppedTokens(
+      droppedLifeTokens,
+      loser.position,
+      tokensDropped,
+    );
+
+    grid = isTeamDead(damagedLoser)
+      ? removeTeamFromGrid(grid, damagedLoser)
+      : updateTeamInGrid(grid, damagedLoser);
+  }
+
+  return {
+    state: { ...state, grid, droppedLifeTokens },
+    results,
+  };
+}

--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -13,6 +13,20 @@ import type { NumberToken, TeamId } from '../types/token.ts';
 /** The four phases of a round, executed in order. */
 export type RoundPhase = 'battle' | 'forbidden' | 'movement' | 'revival';
 
+/**
+ * Dropped life tokens awaiting revival, indexed by grid coordinate.
+ * `droppedLifeTokens[x][y]` is the count of tokens lying at (x, y).
+ */
+export type DroppedTokens = Readonly<
+  Record<ElementCoordinate, Readonly<Record<ElementCoordinate, number>>>
+>;
+
+/** Returns a zero-initialised DroppedTokens map. */
+export function createEmptyDroppedTokens(): DroppedTokens {
+  const row = { fire: 0, water: 0, wood: 0 } as const;
+  return { fire: row, water: row, wood: row } as DroppedTokens;
+}
+
 /** Immutable snapshot of the full game state at any point in a round. */
 export type RoundState = {
   readonly phase: RoundPhase;
@@ -20,13 +34,35 @@ export type RoundState = {
   readonly grid: Grid;
   /** All forbidden cells accumulated so far this game. */
   readonly forbiddenCells: readonly GridCoord[];
+  /**
+   * Life tokens dropped during battle (and movement penalties),
+   * awaiting potential recovery in the revival phase.
+   * Optional for backward compatibility with code that pre-dates
+   * the wave-4 battle-damage extension.
+   */
+  readonly droppedLifeTokens?: DroppedTokens;
 };
 
-/** One encounter result between two teams. */
-export type BattleResult = {
+/**
+ * Identification of a pair of teams that meet on the grid in a
+ * given round, without any resolution information.
+ */
+export type EncounterPair = {
   readonly teamA: TeamId;
   readonly teamB: TeamId;
   readonly encounterType: 'adjacent' | 'same-cell';
+};
+
+/**
+ * Full result of one encounter after card resolution and damage
+ * calculation. Extends {@link EncounterPair} with the resolution
+ * outcome.
+ */
+export type BattleResult = EncounterPair & {
+  /** TeamId of the winner, or null for a draw. */
+  readonly winner: TeamId | null;
+  /** Damage points dealt to the loser (0 on draw). */
+  readonly damage: number;
 };
 
 /** A team's movement card reveal during the movement phase. */
@@ -60,13 +96,17 @@ function isTeamAlive(team: TeamState): boolean {
 }
 
 /**
- * Returns BattleResult[] listing every pair of teams that encounter
- * each other based on grid position (same cell or adjacent cells).
- * Card resolution and damage are handled separately by the caller.
+ * Returns the list of team-pair encounters that would occur this
+ * round, based purely on grid position (same cell or adjacent
+ * cells). No card resolution, no damage application.
+ *
+ * For full battle resolution including card play, damage, and
+ * dropped-token tracking, use `resolveBattlePhase` from
+ * `logic/battle.ts`.
  */
-export function advanceBattle(state: RoundState): BattleResult[] {
+export function advanceBattle(state: RoundState): EncounterPair[] {
   const teams = allTeams(state.grid);
-  const results: BattleResult[] = [];
+  const results: EncounterPair[] = [];
 
   for (let i = 0; i < teams.length; i++) {
     for (let j = i + 1; j < teams.length; j++) {

--- a/packages/core/src/types/grid.ts
+++ b/packages/core/src/types/grid.ts
@@ -1,4 +1,4 @@
-import type { Deck, Element } from './card.ts';
+import type { Card, Deck, Element } from './card.ts';
 import type { LifeToken, NumberToken } from './token.ts';
 
 /** Element value used as a grid axis coordinate. */
@@ -25,9 +25,18 @@ export type PlayerState = {
 export type TeamState = {
   readonly position: GridCoord;
   readonly facing: Facing;
+  /** Cards held in the team's private hand (not on the grid). */
   readonly cards: Deck;
   readonly teamNumber: NumberToken;
   readonly players: readonly PlayerState[];
+  /**
+   * The two attribute cards placed face-up under the team's number
+   * token at its grid coordinate. Used by battle-phase encounter
+   * ordering (pair-sum) and by the descent phase to record the
+   * team's piece. Optional for backward compatibility with test
+   * fixtures that do not exercise positioned-card logic.
+   */
+  readonly gridCards?: readonly [Card, Card];
 };
 
 /** All teams currently standing on one grid cell. */


### PR DESCRIPTION
Closes #100 · Refs roadmap #98

## Summary

- **`packages/core/src/logic/battle.ts`** (new):
  - `BattlePlay` type for per-team card plays (card or null forfeit)
  - `orderEncounters(state)` — same-cell pairs ordered by ascending pair-sum (Joker = 25), with `teamNumber` tiebreaker. Adjacent pairs collected only for teams that didn't pair same-cell. Each team encounters at most once per round.
  - `resolveBattlePhase(state, plays)` — full end-to-end resolution using `resolveCards` + `calcDamage`. Damage hits the lowest-life living player first; tokens drop at the loser's coordinate; teams removed from grid when all players reach life 0. Joker and card-absence wins → fixed damage 1.
- **`packages/core/src/logic/round.ts`**:
  - New `DroppedTokens` type + `createEmptyDroppedTokens` helper
  - `RoundState` gains optional `droppedLifeTokens` field
  - Split `BattleResult` into `EncounterPair` (simple) and `BattleResult` (enriched with `winner` + `damage`). `advanceBattle` now returns `EncounterPair[]`.
- **`packages/core/src/types/grid.ts`**: extends `TeamState` with optional `gridCards` for pair-sum (falls back to `teamNumber × 2` when absent).

## Test plan

- [x] `pnpm run test` — 117 tests pass (17 new for battle)
- [x] `pnpm -r run typecheck` — clean
- [x] `pnpm run lint` — biome + markdown + cspell all clean
- [x] Encounter ordering: 2-team same-cell, 3-team odd-one-out skip, 4-team pair-sum ordering, joker=25, adjacent fallback
- [x] Damage: joker fixed 1, calcDamage path, card-absence (both forfeit / one forfeit), elimination on lethal damage, lowest-life-first distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battle-phase resolution system now includes encounter pairing and damage calculation.
  * Added support for tracking dropped life tokens during battles.
  * Implemented deterministic encounter ordering and multi-player damage targeting.

* **Tests**
  * Added comprehensive test coverage for battle mechanics and encounter resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->