### PR TITLE
feat(core): add deck/graveyard state + runner self-driven phase draws

### DIFF
--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -1,4 +1,4 @@
-import type { Card, Element, ElementCard } from '../types/card.ts';
+import type { Card, Deck, Element, ElementCard } from '../types/card.ts';
 import type {
   ElementCoordinate,
   Facing,
@@ -36,6 +36,16 @@ export type RoundState = {
   readonly grid: Grid;
   /** All forbidden cells accumulated so far this game. */
   readonly forbiddenCells: readonly GridCoord[];
+  /**
+   * Remaining shuffled draw pile. Optional for backward compatibility
+   * with fixtures that pre-date the wave-5 card-economy work.
+   */
+  readonly deck?: Deck;
+  /**
+   * Discarded cards accumulated during play. Optional until battle,
+   * movement, and revival start writing to it in later wave-5 issues.
+   */
+  readonly graveyard?: Deck;
   /**
    * Life tokens dropped during battle (and movement penalties),
    * awaiting potential recovery in the revival phase.

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -264,6 +264,30 @@ describe('runRound', () => {
     expect(out.state.forbiddenCells).toEqual([]);
   });
 
+  it('throws when post-battle phases would run without a deck', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const {
+      deck: _deck,
+      graveyard: _graveyard,
+      ...legacyState
+    } = stateWith([teamA, teamB]);
+
+    expect(() => runRound(legacyState, makeInputs())).toThrow(
+      'RoundState.deck is required to run post-battle phases',
+    );
+  });
+
   it('stops early when game ends mid-round (battle eliminates loser)', () => {
     // Team A: full life. Team B: 1 life. Battle damage will eliminate B.
     const teamA = makeTeam({

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_CONFIG } from '../config.ts';
-import type { Card, JokerCard } from '../types/card.ts';
+import type { Card, ElementCard, JokerCard } from '../types/card.ts';
 import type { GridCoord, TeamState } from '../types/grid.ts';
 import { ELEMENT_AXIS } from '../types/grid.ts';
 import type { NumberToken, TeamId } from '../types/token.ts';
@@ -232,6 +232,36 @@ describe('runRound', () => {
       ),
     ).toBe(true);
     expect(out.state.forbiddenCells).toContainEqual({ x: 'fire', y: 'water' });
+  });
+
+  it('logs deck exhaustion and skips forbidden when deck has fewer than 2 cards', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWithDeck([teamA, teamB], []);
+    const out = runRound(s, makeInputs());
+
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((e) =>
+        e.message.includes('Forbidden phase skipped: deck exhausted'),
+      ),
+    ).toBe(true);
+    expect(
+      out.log.some((e) =>
+        e.message.includes('Movement phase skipped: deck exhausted'),
+      ),
+    ).toBe(true);
+    expect(out.state.forbiddenCells).toEqual([]);
   });
 
   it('stops early when game ends mid-round (battle eliminates loser)', () => {

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_CONFIG } from '../config.ts';
-import type { Card, ElementCard, JokerCard } from '../types/card.ts';
+import type { Card, JokerCard } from '../types/card.ts';
 import type { GridCoord, TeamState } from '../types/grid.ts';
 import { ELEMENT_AXIS } from '../types/grid.ts';
 import type { NumberToken, TeamId } from '../types/token.ts';
@@ -29,6 +29,13 @@ function allTeams(state: RoundState): TeamState[] {
 }
 
 function stateWith(teams: readonly TeamState[]): RoundState {
+  return stateWithDeck(teams, [fire5, water3, wood4]);
+}
+
+function stateWithDeck(
+  teams: readonly TeamState[],
+  deck: readonly Card[],
+): RoundState {
   let grid = createEmptyGrid();
   for (const team of teams) {
     const { x, y } = team.position;
@@ -37,7 +44,14 @@ function stateWith(teams: readonly TeamState[]): RoundState {
       [x]: { ...grid[x], [y]: [...grid[x][y], team] },
     } as typeof grid;
   }
-  return { phase: 'battle', round: 1, grid, forbiddenCells: [] };
+  return {
+    phase: 'battle',
+    round: 1,
+    grid,
+    forbiddenCells: [],
+    deck,
+    graveyard: [],
+  };
 }
 
 const fireWater: GridCoord = { x: 'fire', y: 'water' };
@@ -70,17 +84,13 @@ describe('runRound', () => {
   function makeInputs(
     opts: {
       plays?: readonly BattlePlay[];
-      forbidden?: readonly [ElementCard, ElementCard];
-      movementAttribute?: 'fire' | 'water' | 'wood';
       teamMoves?: readonly TeamMove[];
       revivalChoices?: ReadonlyMap<TeamId, RevivalAction>;
     } = {},
   ): RoundInputs {
     return {
       battle: { plays: opts.plays ?? [] },
-      forbidden: { drawnCards: opts.forbidden ?? [fire5, water3] },
       movement: {
-        attribute: opts.movementAttribute ?? 'fire',
         teamMoves: opts.teamMoves ?? [],
       },
       revival: { choices: opts.revivalChoices ?? new Map() },
@@ -148,12 +158,80 @@ describe('runRound', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
-    const out = runRound(s, makeInputs({ forbidden: [water3, fire5] }));
+    const s = stateWithDeck([teamA, teamB], [water3, fire5, wood4]);
+    const out = runRound(s, makeInputs());
     const forbiddenLogs = out.log.filter((e) => e.phase === 'forbidden');
     expect(forbiddenLogs).toHaveLength(1);
     expect(forbiddenLogs[0]?.message).toContain('water');
     expect(forbiddenLogs[0]?.message).toContain('fire');
+  });
+
+  it('maps a joker forbidden draw to fire deterministically', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWithDeck([teamA, teamB], [joker, water3, wood4]);
+    const out = runRound(s, makeInputs());
+    const forbiddenLogs = out.log.filter((e) => e.phase === 'forbidden');
+
+    expect(forbiddenLogs).toHaveLength(1);
+    expect(forbiddenLogs[0]?.message).toContain('fire');
+    expect(forbiddenLogs[0]?.message).toContain('water');
+    expect(out.state.forbiddenCells).toContainEqual({ x: 'fire', y: 'water' });
+  });
+
+  it('draws forbidden and movement cards from deck and shrinks it by 3', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWithDeck([teamA, teamB], [fire5, water3, wood4]);
+    const out = runRound(s, makeInputs());
+
+    expect(out.state.deck).toEqual([]);
+    expect(out.state.forbiddenCells).toContainEqual({ x: 'fire', y: 'water' });
+  });
+
+  it('logs deck exhaustion and skips movement when only forbidden draw succeeds', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWithDeck([teamA, teamB], [fire5, water3]);
+    const out = runRound(s, makeInputs());
+
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((e) =>
+        e.message.includes('Movement phase skipped: deck exhausted'),
+      ),
+    ).toBe(true);
+    expect(out.state.forbiddenCells).toContainEqual({ x: 'fire', y: 'water' });
   });
 
   it('stops early when game ends mid-round (battle eliminates loser)', () => {
@@ -242,8 +320,7 @@ describe('runUntilGameOver', () => {
           { teamId: 2 as NumberToken, card: wood4 },
         ],
       },
-      forbidden: { drawnCards: [fire5, water3] },
-      movement: { attribute: 'fire', teamMoves: [] },
+      movement: { teamMoves: [] },
       revival: { choices: new Map() },
     });
 
@@ -269,8 +346,12 @@ describe('runUntilGameOver', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
-    const woodPin: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+    const safeDeck: Card[] = Array.from({ length: 5 }, () => [
+      wood1,
+      wood1,
+      fire5,
+    ]).flat();
+    const s = stateWithDeck([teamA, teamB], safeDeck);
     const provider: InputProvider = () => ({
       battle: {
         plays: [
@@ -278,9 +359,7 @@ describe('runUntilGameOver', () => {
           { teamId: 2 as NumberToken, card: null },
         ],
       },
-      // Forbidden cell at (wood, wood) — neither team occupies it.
-      forbidden: { drawnCards: [woodPin, woodPin] },
-      movement: { attribute: 'fire', teamMoves: [] },
+      movement: { teamMoves: [] },
       revival: { choices: new Map() },
     });
     const result = runUntilGameOver(s, provider, 5);
@@ -302,9 +381,7 @@ describe('runUntilGameOver', () => {
             card: joker as Card,
           })),
         },
-        forbidden: { drawnCards: [fire5, water3] },
         movement: {
-          attribute: 'fire',
           teamMoves: teams.map((t) => ({
             teamId: t.teamNumber,
             card: fire5 as Card,

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -48,7 +48,7 @@ function battleLogMessage(result: BattleResult): string {
 const JOKER_PHASE_ELEMENT: Element = 'fire';
 
 function drawCards(
-  deck: RoundState['deck'],
+  deck: readonly Card[],
   count: number,
 ):
   | {
@@ -56,13 +56,22 @@ function drawCards(
       readonly remainingDeck: readonly Card[];
     }
   | undefined {
-  if (deck === undefined || deck.length < count) {
+  if (deck.length < count) {
     return undefined;
   }
   return {
     drawn: deck.slice(0, count),
     remainingDeck: deck.slice(count),
   };
+}
+
+function requireDeckState(
+  state: RoundState,
+): RoundState & { readonly deck: readonly Card[] } {
+  if (state.deck === undefined) {
+    throw new Error('RoundState.deck is required to run post-battle phases');
+  }
+  return state as RoundState & { readonly deck: readonly Card[] };
 }
 
 function phaseElement(card: Card): Element {
@@ -110,9 +119,10 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   }
 
   // Phase 2: forbidden
-  const forbiddenDraw = drawCards(next.deck, 2);
+  const forbiddenState = requireDeckState(next);
+  const forbiddenDraw = drawCards(forbiddenState.deck, 2);
   if (forbiddenDraw === undefined) {
-    next = { ...next, phase: 'movement' };
+    next = { ...forbiddenState, phase: 'movement' };
     log.push({
       round,
       phase: 'forbidden',
@@ -124,7 +134,7 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
       forbiddenCard(forbiddenDraw.drawn[1] as Card),
     ] as const;
     next = advanceForbidden(
-      { ...next, deck: forbiddenDraw.remainingDeck },
+      { ...forbiddenState, deck: forbiddenDraw.remainingDeck },
       drawnCards,
     );
     log.push({
@@ -138,9 +148,10 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   }
 
   // Phase 3: movement
-  const movementDraw = drawCards(next.deck, 1);
+  const movementState = requireDeckState(next);
+  const movementDraw = drawCards(movementState.deck, 1);
   if (movementDraw === undefined) {
-    next = { ...next, phase: 'revival' };
+    next = { ...movementState, phase: 'revival' };
     log.push({
       round,
       phase: 'movement',
@@ -148,7 +159,10 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
     });
   } else {
     const movementAttribute = phaseElement(movementDraw.drawn[0] as Card);
-    const beforeMovement = { ...next, deck: movementDraw.remainingDeck };
+    const beforeMovement = {
+      ...movementState,
+      deck: movementDraw.remainingDeck,
+    };
     next = advanceMovement(
       beforeMovement,
       movementAttribute,

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -1,4 +1,4 @@
-import type { Element, ElementCard } from '../types/card.ts';
+import type { Card, Element, ElementCard } from '../types/card.ts';
 import type { LogEntry } from '../types/log.ts';
 import type { TeamId } from '../types/token.ts';
 import type { BattlePlay } from './battle.ts';
@@ -22,11 +22,7 @@ export type RoundInputs = {
   readonly battle: {
     readonly plays: readonly BattlePlay[];
   };
-  readonly forbidden: {
-    readonly drawnCards: readonly [ElementCard, ElementCard];
-  };
   readonly movement: {
-    readonly attribute: Element;
     readonly teamMoves: readonly TeamMove[];
   };
   readonly revival: {
@@ -49,9 +45,45 @@ function battleLogMessage(result: BattleResult): string {
   return `Team ${result.winner} hit Team ${loser} for ${result.damage} damage (${result.encounterType})`;
 }
 
+const JOKER_PHASE_ELEMENT: Element = 'fire';
+
+function drawCards(
+  deck: RoundState['deck'],
+  count: number,
+):
+  | {
+      readonly drawn: readonly Card[];
+      readonly remainingDeck: readonly Card[];
+    }
+  | undefined {
+  if (deck === undefined || deck.length < count) {
+    return undefined;
+  }
+  return {
+    drawn: deck.slice(0, count),
+    remainingDeck: deck.slice(count),
+  };
+}
+
+function phaseElement(card: Card): Element {
+  return card.kind === 'element' ? card.element : JOKER_PHASE_ELEMENT;
+}
+
+function forbiddenCard(card: Card): ElementCard {
+  if (card.kind === 'element') {
+    return card;
+  }
+  // Jokers do not encode an element, so keep runner-controlled draws deterministic.
+  return { kind: 'element', element: JOKER_PHASE_ELEMENT, value: 1 };
+}
+
 /**
  * Runs the four phases of a single round in order:
  *   battle → forbidden → movement → revival.
+ *
+ * The runner self-draws the forbidden and movement phase cards from
+ * `state.deck`. If the deck cannot satisfy a phase's draw count, that
+ * phase is skipped with a `deck exhausted` log entry.
  *
  * After each phase, checks {@link isGameOver}; if true, subsequent
  * phases are skipped and the partial log is returned. Battle results
@@ -78,37 +110,64 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   }
 
   // Phase 2: forbidden
-  next = advanceForbidden(next, inputs.forbidden.drawnCards);
-  const f = inputs.forbidden.drawnCards;
-  log.push({
-    round,
-    phase: 'forbidden',
-    message: `New forbidden cell: (${f[0].element}, ${f[1].element})`,
-  });
+  const forbiddenDraw = drawCards(next.deck, 2);
+  if (forbiddenDraw === undefined) {
+    next = { ...next, phase: 'movement' };
+    log.push({
+      round,
+      phase: 'forbidden',
+      message: 'Forbidden phase skipped: deck exhausted',
+    });
+  } else {
+    const drawnCards = [
+      forbiddenCard(forbiddenDraw.drawn[0] as Card),
+      forbiddenCard(forbiddenDraw.drawn[1] as Card),
+    ] as const;
+    next = advanceForbidden(
+      { ...next, deck: forbiddenDraw.remainingDeck },
+      drawnCards,
+    );
+    log.push({
+      round,
+      phase: 'forbidden',
+      message: `New forbidden cell: (${drawnCards[0].element}, ${drawnCards[1].element})`,
+    });
+  }
   if (isGameOver(next)) {
     return { state: next, battleResults, log };
   }
 
   // Phase 3: movement
-  const beforeMovement = next;
-  next = advanceMovement(
-    next,
-    inputs.movement.attribute,
-    inputs.movement.teamMoves,
-  );
-  log.push({
-    round,
-    phase: 'movement',
-    message: `Movement attribute: ${inputs.movement.attribute} (${inputs.movement.teamMoves.length} moves submitted)`,
-  });
-  // Tally any forbidden-cell penalties applied during movement.
-  const movementPenalties = countTokenDelta(beforeMovement, next);
-  if (movementPenalties > 0) {
+  const movementDraw = drawCards(next.deck, 1);
+  if (movementDraw === undefined) {
+    next = { ...next, phase: 'revival' };
     log.push({
       round,
       phase: 'movement',
-      message: `Forbidden-cell penalty dropped ${movementPenalties} life token(s)`,
+      message: 'Movement phase skipped: deck exhausted',
     });
+  } else {
+    const movementAttribute = phaseElement(movementDraw.drawn[0] as Card);
+    const beforeMovement = { ...next, deck: movementDraw.remainingDeck };
+    next = advanceMovement(
+      beforeMovement,
+      movementAttribute,
+      inputs.movement.teamMoves,
+    );
+    log.push({
+      round,
+      phase: 'movement',
+      message: `Movement attribute: ${movementAttribute} (${inputs.movement.teamMoves.length} moves submitted)`,
+    });
+    // Tally any forbidden-cell penalties applied during movement.
+    const movementPenalties = countTokenDelta(beforeMovement, next);
+    if (movementPenalties > 0) {
+      log.push({
+        round,
+        phase: 'movement',
+        message: `Forbidden-cell penalty dropped ${movementPenalties} life token(s)`,
+      });
+    }
   }
   if (isGameOver(next)) {
     return { state: next, battleResults, log };

--- a/packages/core/src/logic/setup.test.ts
+++ b/packages/core/src/logic/setup.test.ts
@@ -4,6 +4,7 @@ import type { Card } from '../types/card.ts';
 import { isJokerCard } from '../types/card.ts';
 import type { TeamState } from '../types/grid.ts';
 import { ELEMENT_AXIS } from '../types/grid.ts';
+import { buildDeck } from './deck.ts';
 import type { RoundState } from './round.ts';
 import { setupGame } from './setup.ts';
 
@@ -27,6 +28,22 @@ describe('setupGame', () => {
     expect(state.phase).toBe('battle');
     expect(state.round).toBe(1);
     expect(state.forbiddenCells).toEqual([]);
+    expect(state.graveyard).toEqual([]);
+    expect(state.deck).toBeDefined();
+    expect(state.deck?.length).toBeGreaterThan(0);
+  });
+
+  it('stores the remaining shuffled cards as the draw deck', () => {
+    const state = setupGame({ playerCount: 4, seed: 1 }, DEFAULT_CONFIG);
+    const teamCount = allTeams(state).length;
+    const setupBatchSize = teamCount * DEFAULT_CONFIG.deckExtractFactor + 2;
+    const expectedDeckSize =
+      buildDeck(DEFAULT_CONFIG).length -
+      setupBatchSize * 3 -
+      1 -
+      teamCount * DEFAULT_CONFIG.randomCardsDealt;
+
+    expect(state.deck).toHaveLength(expectedDeckSize);
   });
 
   it('creates 1 pair team for 2 players', () => {

--- a/packages/core/src/logic/setup.ts
+++ b/packages/core/src/logic/setup.ts
@@ -233,5 +233,7 @@ export function setupGame(input: SetupInput, config: GameConfig): RoundState {
     round: 1,
     grid,
     forbiddenCells: [],
+    deck: shuffled,
+    graveyard: [],
   };
 }


### PR DESCRIPTION
## Summary

- add optional `deck` and `graveyard` fields to `RoundState` and seed them from `setupGame`
- make `runRound` draw forbidden and movement phase cards from `state.deck`, including deterministic joker fallback and explicit deck-exhaustion skips
- update setup and runner tests for deck sizing, per-round shrinkage, exhaustion handling, and the new `RoundInputs` shape

## Validation

- `pnpm run lint:fix`
- `pnpm run test`
- `pnpm -r typecheck`
- `pnpm run lint`

## Follow-ups

- #109 consumes battle cards from hands and writes to `state.graveyard`
- #111 swaps grid cards during movement using the new shared deck/graveyard state
- #112 adds revival deck-draw bonuses on top of the same state
- #110 depends on #109 and remains intentionally separate

Closes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Game state now tracks the draw deck and graveyard; setup preserves a shuffled draw deck and initializes an empty graveyard.
  * Round processing now draws required forbidden/movement cards from the deck and skips phases with log entries when the deck is exhausted.
  * Runner now enforces presence of a deck and will error if missing during post-battle phases.

* **Bug Fixes**
  * Forbidden and movement are sourced from the draw deck, and draws consume deck cards as expected.

* **Tests**
  * Added/updated tests to verify deck handling, graveyard initialization, phase-skip and deck-exhaustion behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->