### PR TITLE
feat(core): add deck/graveyard state + runner self-driven phase draws

### DIFF
--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -1,4 +1,4 @@
-import type { Card, Element, ElementCard } from '../types/card.ts';
+import type { Card, Deck, Element, ElementCard } from '../types/card.ts';
 import type {
   ElementCoordinate,
   Facing,
@@ -43,6 +43,23 @@ export type RoundState = {
    * the wave-4 battle-damage extension.
    */
   readonly droppedLifeTokens?: DroppedTokens;
+  /**
+   * Remaining shuffled deck. The runner pops cards from here during
+   * forbidden and movement phases; the revival phase consumes cards
+   * for deck-draw bonuses (#112). Optional for backward
+   * compatibility — when undefined, phases requiring a draw skip
+   * with a "deck exhausted" log entry.
+   */
+  readonly deck?: Deck;
+  /**
+   * Discarded card pile. Cards consumed during battle (played
+   * cards, forfeit drops) and movement (swapped grid cards) are
+   * appended here. Forbidden / movement draws are conceptually
+   * consumed (placed on the grid as markers / phase results) and
+   * do NOT pass through the graveyard. Optional for backward
+   * compatibility.
+   */
+  readonly graveyard?: Deck;
 };
 
 /**

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -12,10 +12,11 @@ import type { InputProvider, RoundInputs } from './runner.ts';
 import { runRound, runUntilGameOver } from './runner.ts';
 import { setupGame } from './setup.ts';
 
+const fire1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
 const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
 const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
-const wood4: ElementCard = { kind: 'element', element: 'wood', value: 4 };
 const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+const wood4: ElementCard = { kind: 'element', element: 'wood', value: 4 };
 const joker: JokerCard = { kind: 'joker' };
 
 function allTeams(state: RoundState): TeamState[] {
@@ -28,7 +29,10 @@ function allTeams(state: RoundState): TeamState[] {
   return teams;
 }
 
-function stateWith(teams: readonly TeamState[]): RoundState {
+function stateWith(
+  teams: readonly TeamState[],
+  deck: readonly Card[] = [],
+): RoundState {
   let grid = createEmptyGrid();
   for (const team of teams) {
     const { x, y } = team.position;
@@ -37,7 +41,14 @@ function stateWith(teams: readonly TeamState[]): RoundState {
       [x]: { ...grid[x], [y]: [...grid[x][y], team] },
     } as typeof grid;
   }
-  return { phase: 'battle', round: 1, grid, forbiddenCells: [] };
+  return {
+    phase: 'battle',
+    round: 1,
+    grid,
+    forbiddenCells: [],
+    deck: [...deck],
+    graveyard: [],
+  };
 }
 
 const fireWater: GridCoord = { x: 'fire', y: 'water' };
@@ -66,23 +77,28 @@ function makeTeam(opts: {
   };
 }
 
+/** Builds a deck with three (forbidden-x, forbidden-y, movement-attr) triples. */
+function deckOfTriples(
+  triples: readonly (readonly [Card, Card, Card])[],
+): Card[] {
+  const out: Card[] = [];
+  for (const t of triples) {
+    out.push(t[0], t[1], t[2]);
+  }
+  return out;
+}
+
 describe('runRound', () => {
   function makeInputs(
     opts: {
       plays?: readonly BattlePlay[];
-      forbidden?: readonly [ElementCard, ElementCard];
-      movementAttribute?: 'fire' | 'water' | 'wood';
       teamMoves?: readonly TeamMove[];
       revivalChoices?: ReadonlyMap<TeamId, RevivalAction>;
     } = {},
   ): RoundInputs {
     return {
       battle: { plays: opts.plays ?? [] },
-      forbidden: { drawnCards: opts.forbidden ?? [fire5, water3] },
-      movement: {
-        attribute: opts.movementAttribute ?? 'fire',
-        teamMoves: opts.teamMoves ?? [],
-      },
+      movement: { teamMoves: opts.teamMoves ?? [] },
       revival: { choices: opts.revivalChoices ?? new Map() },
     };
   }
@@ -100,7 +116,7 @@ describe('runRound', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
+    const s = stateWith([teamA, teamB], deckOfTriples([[wood1, wood1, fire5]]));
     const out = runRound(s, makeInputs());
     // After full round, revival advances round to 2
     expect(out.state.round).toBe(2);
@@ -120,7 +136,7 @@ describe('runRound', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
+    const s = stateWith([teamA, teamB], deckOfTriples([[wood1, wood1, fire5]]));
     const out = runRound(
       s,
       makeInputs({
@@ -135,7 +151,7 @@ describe('runRound', () => {
     expect(battleLogs[0]?.message).toContain('Team 1');
   });
 
-  it('logs the new forbidden cell', () => {
+  it('draws the forbidden coord from the top of state.deck', () => {
     const teamA = makeTeam({
       id: 1 as NumberToken,
       position: fireWater,
@@ -148,16 +164,101 @@ describe('runRound', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
-    const out = runRound(s, makeInputs({ forbidden: [water3, fire5] }));
+    const s = stateWith([teamA, teamB], [water3, fire5, fire5]);
+    const out = runRound(s, makeInputs());
     const forbiddenLogs = out.log.filter((e) => e.phase === 'forbidden');
     expect(forbiddenLogs).toHaveLength(1);
     expect(forbiddenLogs[0]?.message).toContain('water');
     expect(forbiddenLogs[0]?.message).toContain('fire');
+    expect(out.state.forbiddenCells).toContainEqual({ x: 'water', y: 'fire' });
+  });
+
+  it('consumes 3 cards per round from state.deck (2 forbidden + 1 movement)', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const deck = deckOfTriples([[wood1, wood1, fire5]]);
+    const s = stateWith([teamA, teamB], deck);
+    const out = runRound(s, makeInputs());
+    expect(s.deck).toHaveLength(3);
+    expect(out.state.deck).toHaveLength(0);
+  });
+
+  it('skips forbidden phase when deck has fewer than 2 cards', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB], [wood1]); // only 1 card
+    const out = runRound(s, makeInputs());
+    const forbiddenLogs = out.log.filter((e) => e.phase === 'forbidden');
+    expect(forbiddenLogs).toHaveLength(1);
+    expect(forbiddenLogs[0]?.message).toContain('exhausted');
+    // No new forbidden cell added because phase skipped
+    expect(out.state.forbiddenCells).toEqual([]);
+  });
+
+  it('skips movement phase when deck is empty after forbidden draw', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1]); // forbidden draws both, none for movement
+    const out = runRound(s, makeInputs());
+    const movementLogs = out.log.filter((e) => e.phase === 'movement');
+    expect(movementLogs.length).toBeGreaterThanOrEqual(1);
+    expect(movementLogs.some((l) => l.message.includes('exhausted'))).toBe(
+      true,
+    );
+  });
+
+  it('treats a drawn Joker as the fire-element fallback for forbidden coord', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood1, wood4],
+    });
+    const s = stateWith([teamA, teamB], [joker, water3, fire5]);
+    const out = runRound(s, makeInputs());
+    expect(out.state.forbiddenCells).toContainEqual({
+      x: 'fire',
+      y: 'water',
+    });
   });
 
   it('stops early when game ends mid-round (battle eliminates loser)', () => {
-    // Team A: full life. Team B: 1 life. Battle damage will eliminate B.
     const teamA = makeTeam({
       id: 1 as NumberToken,
       position: fireWater,
@@ -170,7 +271,7 @@ describe('runRound', () => {
       life: 1,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
+    const s = stateWith([teamA, teamB], deckOfTriples([[wood1, wood1, fire5]]));
     const out = runRound(
       s,
       makeInputs({
@@ -181,7 +282,6 @@ describe('runRound', () => {
       }),
     );
     expect(isGameOver(out.state)).toBe(true);
-    // Forbidden / movement / revival should NOT have run
     const forbiddenLogs = out.log.filter((e) => e.phase === 'forbidden');
     expect(forbiddenLogs).toHaveLength(0);
   });
@@ -199,8 +299,12 @@ describe('runRound', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
+    const baseState = stateWith(
+      [teamA, teamB],
+      deckOfTriples([[wood1, wood1, fire5]]),
+    );
     const initialState: RoundState = {
-      ...stateWith([teamA, teamB]),
+      ...baseState,
       droppedLifeTokens: {
         fire: { fire: 0, water: 1, wood: 0 },
         water: { fire: 0, water: 0, wood: 0 },
@@ -220,7 +324,6 @@ describe('runRound', () => {
 
 describe('runUntilGameOver', () => {
   it('terminates within maxRounds and returns winner', () => {
-    // 2-team setup, scripted provider: team 1 always wins via joker
     const teamA = makeTeam({
       id: 1 as NumberToken,
       position: fireWater,
@@ -233,7 +336,11 @@ describe('runUntilGameOver', () => {
       life: 2,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
+    // Plenty of deck for up to 10 rounds × 3 draws each.
+    const deck = Array.from({ length: 30 }, (_, i) =>
+      i % 3 === 2 ? fire5 : wood1,
+    );
+    const s = stateWith([teamA, teamB], deck);
 
     const provider: InputProvider = () => ({
       battle: {
@@ -242,8 +349,7 @@ describe('runUntilGameOver', () => {
           { teamId: 2 as NumberToken, card: wood4 },
         ],
       },
-      forbidden: { drawnCards: [fire5, water3] },
-      movement: { attribute: 'fire', teamMoves: [] },
+      movement: { teamMoves: [] },
       revival: { choices: new Map() },
     });
 
@@ -254,9 +360,6 @@ describe('runUntilGameOver', () => {
   });
 
   it('caps at maxRounds when game does not end', () => {
-    // 2 teams that draw every round → never ends.
-    // Forbidden cell points at an unoccupied coordinate to avoid
-    // the movement-phase penalty eliminating teams over time.
     const teamA = makeTeam({
       id: 1 as NumberToken,
       position: fireWater,
@@ -269,8 +372,13 @@ describe('runUntilGameOver', () => {
       life: 4,
       gridCards: [wood1, wood4],
     });
-    const s = stateWith([teamA, teamB]);
-    const woodPin: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+    // Each round's forbidden draws both wood (so cell = wood,wood,
+    // unoccupied) and movement attribute is wood (neither team's
+    // movement card matches → only rotates, no position change).
+    const deck = deckOfTriples(
+      Array.from({ length: 6 }, () => [wood1, wood1, wood4] as const),
+    );
+    const s = stateWith([teamA, teamB], deck);
     const provider: InputProvider = () => ({
       battle: {
         plays: [
@@ -278,9 +386,7 @@ describe('runUntilGameOver', () => {
           { teamId: 2 as NumberToken, card: null },
         ],
       },
-      // Forbidden cell at (wood, wood) — neither team occupies it.
-      forbidden: { drawnCards: [woodPin, woodPin] },
-      movement: { attribute: 'fire', teamMoves: [] },
+      movement: { teamMoves: [] },
       revival: { choices: new Map() },
     });
     const result = runUntilGameOver(s, provider, 5);
@@ -288,8 +394,9 @@ describe('runUntilGameOver', () => {
     expect(isGameOver(result.state)).toBe(false);
   });
 
-  it('integrates with setupGame', () => {
+  it('integrates with setupGame (deck populated by setup)', () => {
     const initial = setupGame({ playerCount: 4, seed: 7 }, DEFAULT_CONFIG);
+    expect((initial.deck ?? []).length).toBeGreaterThan(0);
     const teamIds = allTeams(initial).map((t) => t.teamNumber);
     expect(teamIds.length).toBe(2);
     // Scripted: each team always plays a joker (always wins or draws)
@@ -302,12 +409,10 @@ describe('runUntilGameOver', () => {
             card: joker as Card,
           })),
         },
-        forbidden: { drawnCards: [fire5, water3] },
         movement: {
-          attribute: 'fire',
           teamMoves: teams.map((t) => ({
             teamId: t.teamNumber,
-            card: fire5 as Card,
+            card: fire1 as Card,
             intendedFacing: t.facing,
           })),
         },

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -1,4 +1,5 @@
-import type { Element, ElementCard } from '../types/card.ts';
+import type { Card, Deck, ElementCard } from '../types/card.ts';
+import { isElementCard } from '../types/card.ts';
 import type { LogEntry } from '../types/log.ts';
 import type { TeamId } from '../types/token.ts';
 import type { BattlePlay } from './battle.ts';
@@ -17,16 +18,19 @@ import {
   winner,
 } from './round.ts';
 
-/** Inputs for a single round, one bundle per phase. */
+/**
+ * Inputs for a single round, one bundle per phase.
+ *
+ * Forbidden and movement-attribute draws are NOT in inputs — they
+ * come from `state.deck`, drawn by the runner. Callers only supply
+ * player-controlled decisions (battle plays, movement choices,
+ * revival actions).
+ */
 export type RoundInputs = {
   readonly battle: {
     readonly plays: readonly BattlePlay[];
   };
-  readonly forbidden: {
-    readonly drawnCards: readonly [ElementCard, ElementCard];
-  };
   readonly movement: {
-    readonly attribute: Element;
     readonly teamMoves: readonly TeamMove[];
   };
   readonly revival: {
@@ -50,12 +54,49 @@ function battleLogMessage(result: BattleResult): string {
 }
 
 /**
+ * Draws up to `count` cards from the head of the deck.
+ * Returns the drawn cards (in original order) and the remaining deck.
+ * Caller is responsible for handling fewer-than-`count` draws.
+ */
+function drawFromDeck(
+  deck: Deck | undefined,
+  count: number,
+): { drawn: readonly Card[]; remaining: Deck } {
+  const source = deck ?? [];
+  const drawn = source.slice(0, count);
+  const remaining = source.slice(count);
+  return { drawn, remaining };
+}
+
+/**
+ * Forbidden-phase Joker fallback: when the GM "draws" a Joker for
+ * the forbidden cell coordinate, the rules call for an "attribute
+ * card" but don't define joker semantics for the forbidden marker.
+ * v1 uses 'fire' as a deterministic fallback element coordinate.
+ */
+const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
+  kind: 'element',
+  element: 'fire',
+  value: 1,
+};
+
+function coerceToElementCard(card: Card): ElementCard {
+  return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
+}
+
+/**
  * Runs the four phases of a single round in order:
  *   battle → forbidden → movement → revival.
  *
  * After each phase, checks {@link isGameOver}; if true, subsequent
  * phases are skipped and the partial log is returned. Battle results
  * are always taken from the (possibly empty) battle phase output.
+ *
+ * Forbidden and movement-attribute cards are drawn from
+ * `state.deck`. When the deck has fewer cards than the phase
+ * requires, the phase is skipped and a "deck exhausted" log entry
+ * is recorded (the game continues with no new forbidden cell or no
+ * movement that round).
  *
  * Note: the returned state's `round` number is incremented by the
  * revival phase to indicate the next round. If revival is skipped
@@ -77,38 +118,61 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
     return { state: next, battleResults, log };
   }
 
-  // Phase 2: forbidden
-  next = advanceForbidden(next, inputs.forbidden.drawnCards);
-  const f = inputs.forbidden.drawnCards;
-  log.push({
-    round,
-    phase: 'forbidden',
-    message: `New forbidden cell: (${f[0].element}, ${f[1].element})`,
-  });
+  // Phase 2: forbidden — draw 2 cards from state.deck.
+  const forbiddenDraw = drawFromDeck(next.deck, 2);
+  if (forbiddenDraw.drawn.length < 2) {
+    log.push({
+      round,
+      phase: 'forbidden',
+      message: 'Deck exhausted: forbidden phase skipped',
+    });
+  } else {
+    const cardX = coerceToElementCard(forbiddenDraw.drawn[0] as Card);
+    const cardY = coerceToElementCard(forbiddenDraw.drawn[1] as Card);
+    next = advanceForbidden({ ...next, deck: forbiddenDraw.remaining }, [
+      cardX,
+      cardY,
+    ]);
+    log.push({
+      round,
+      phase: 'forbidden',
+      message: `New forbidden cell: (${cardX.element}, ${cardY.element})`,
+    });
+  }
   if (isGameOver(next)) {
     return { state: next, battleResults, log };
   }
 
-  // Phase 3: movement
-  const beforeMovement = next;
-  next = advanceMovement(
-    next,
-    inputs.movement.attribute,
-    inputs.movement.teamMoves,
-  );
-  log.push({
-    round,
-    phase: 'movement',
-    message: `Movement attribute: ${inputs.movement.attribute} (${inputs.movement.teamMoves.length} moves submitted)`,
-  });
-  // Tally any forbidden-cell penalties applied during movement.
-  const movementPenalties = countTokenDelta(beforeMovement, next);
-  if (movementPenalties > 0) {
+  // Phase 3: movement — draw 1 card from state.deck for attribute.
+  const moveDraw = drawFromDeck(next.deck, 1);
+  if (moveDraw.drawn.length < 1) {
     log.push({
       round,
       phase: 'movement',
-      message: `Forbidden-cell penalty dropped ${movementPenalties} life token(s)`,
+      message: 'Deck exhausted: movement phase skipped',
     });
+  } else {
+    const drawn = moveDraw.drawn[0] as Card;
+    const attrCard = coerceToElementCard(drawn);
+    const beforeMovement: RoundState = { ...next, deck: moveDraw.remaining };
+    next = advanceMovement(
+      beforeMovement,
+      attrCard.element,
+      inputs.movement.teamMoves,
+    );
+    log.push({
+      round,
+      phase: 'movement',
+      message: `Movement attribute: ${attrCard.element} (${inputs.movement.teamMoves.length} moves submitted)`,
+    });
+    const movementPenalties = countTokenDelta(beforeMovement, next);
+    if (movementPenalties > 0) {
+      log.push({
+        round,
+        phase: 'movement',
+        message: `Forbidden-cell penalty dropped ${movementPenalties} life token(s)`,
+      });
+    }
   }
   if (isGameOver(next)) {
     return { state: next, battleResults, log };

--- a/packages/core/src/logic/setup.ts
+++ b/packages/core/src/logic/setup.ts
@@ -233,5 +233,9 @@ export function setupGame(input: SetupInput, config: GameConfig): RoundState {
     round: 1,
     grid,
     forbiddenCells: [],
+    // Whatever is left in the shuffled deck after dealing becomes
+    // the runtime draw pile (forbidden / movement / revival).
+    deck: shuffled,
+    graveyard: [],
   };
 }


### PR DESCRIPTION
Closes #108 · Refs roadmap #107

Foundation for wave-5. Wave-4 left forbidden / movement card draws
as caller-supplied inputs and never tracked the deck or graveyard
in state. This PR moves the deck into \`RoundState\` and has the
runner pop draws from it.

## Summary

- **\`RoundState\`** extended with optional \`deck: Deck\` and
  \`graveyard: Deck\`. Both optional to preserve wave-4 fixtures.
- **\`setupGame\`** populates \`state.deck\` with the post-deal
  remainder of the shuffled pile and \`state.graveyard\` with \`[]\`.
- **\`RoundInputs\`** simplified: dropped \`forbidden.drawnCards\`
  and \`movement.attribute\`. Callers now only supply player
  decisions; the engine handles GM draws.
- **\`runRound\`** pops 2 cards from \`state.deck\` for the forbidden
  cell and 1 for the movement attribute. A drawn Joker fallbacks
  to \`'fire'\` element coordinate (documented inline). Deck
  exhaustion is non-fatal: the phase is skipped with a
  "Deck exhausted" log entry.

## Test plan

- [x] \`pnpm run test\` — 164 tests pass (4 new for deck draws + exhaustion + joker fallback)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome + markdown + cspell all clean
- [x] Deck consumption: 3 cards per full round (verified)
- [x] Forbidden draw of Joker → 'fire' fallback (verified)
- [x] Deck exhaustion → phase skipped with log entry (verified for forbidden + movement)
- [x] Integration with \`setupGame\` — \`runUntilGameOver\` continues to terminate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the round system to manage the game deck and graveyard directly during gameplay, improving how cards are drawn for forbidden markers and movement phases.

* **Tests**
  * Enhanced test coverage for the new round mechanics, including deck exhaustion scenarios and phase behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->