### PR TITLE
feat(core): consume battle-played cards from hand + validate plays

### DIFF
--- a/packages/core/src/logic/battle.test.ts
+++ b/packages/core/src/logic/battle.test.ts
@@ -25,6 +25,7 @@ function makeTeam(opts: {
   life?: number;
   members?: 1 | 2;
   gridCards?: readonly [Card, Card];
+  cards?: readonly Card[];
 }): TeamState {
   const facing = opts.facing ?? 'north';
   const life = opts.life ?? 2;
@@ -37,7 +38,7 @@ function makeTeam(opts: {
     teamNumber: opts.id,
     position: opts.position,
     facing,
-    cards: [],
+    cards: opts.cards ?? [],
     players,
     ...(opts.gridCards ? { gridCards: opts.gridCards } : {}),
   };
@@ -241,6 +242,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
@@ -249,6 +251,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [wood1, wood4],
+      cards: [wood4],
     });
     const s = stateWith([teamA, teamB]);
     const out = resolveBattlePhase(s, [
@@ -273,6 +276,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [joker, joker],
+      cards: [joker],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
@@ -281,6 +285,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const s = stateWith([teamA, teamB]);
     const out = resolveBattlePhase(s, [
@@ -322,6 +327,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
@@ -346,6 +352,7 @@ describe('resolveBattlePhase', () => {
       life: 1,
       members: 1,
       gridCards: [wood1, wood4],
+      cards: [wood1],
     });
     const winnerTeam = makeTeam({
       id: 1 as NumberToken,
@@ -354,6 +361,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const s = stateWith([winnerTeam, loser]);
     const out = resolveBattlePhase(s, [
@@ -375,6 +383,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const b = makeTeam({
       id: 2 as NumberToken,
@@ -382,6 +391,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [wood1, wood4],
+      cards: [fire9],
     });
     const s = stateWith([a, b]);
     const out = resolveBattlePhase(s, [
@@ -402,12 +412,13 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire13, water3],
+      cards: [fire13],
     });
     const teamB: TeamState = {
       teamNumber: 2 as NumberToken,
       position: fireWater,
       facing: 'south',
-      cards: [],
+      cards: [wood1],
       players: [{ life: createLifeToken(1) }, { life: createLifeToken(4) }],
       gridCards: [wood1, wood4],
     };
@@ -437,6 +448,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [wood1, wood1],
+      cards: [wood1],
     });
     const b = makeTeam({
       id: 2 as NumberToken,
@@ -445,6 +457,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const c = makeTeam({
       id: 3 as NumberToken,
@@ -453,6 +466,7 @@ describe('resolveBattlePhase', () => {
       life: 4,
       members: 1,
       gridCards: [fire13, wood12],
+      cards: [fire5],
     });
     const s = stateWith([a, b, c]);
     const out = resolveBattlePhase(s, [
@@ -462,5 +476,187 @@ describe('resolveBattlePhase', () => {
     ]);
     // Only 1 encounter pair this round
     expect(out.results).toHaveLength(1);
+  });
+});
+
+describe('resolveBattlePhase — hand consumption + validation', () => {
+  function play(teamId: NumberToken, card: Card | null): BattlePlay {
+    return { teamId, card };
+  }
+
+  it('removes the played card from the team hand', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5, joker],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood4),
+    ]);
+    const newA = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    const newB = out.state.grid.fire.water.find((t) => t.teamNumber === 2);
+    expect(newA?.cards).toEqual([joker]);
+    expect(newB?.cards).toEqual([]);
+  });
+
+  it('appends consumed cards to the graveyard', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood4),
+    ]);
+    expect(out.state.graveyard).toHaveLength(2);
+    expect(out.state.graveyard).toContainEqual(fire5);
+    expect(out.state.graveyard).toContainEqual(wood4);
+  });
+
+  it('removes only one matching card when hand contains duplicates', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5, fire5],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood4),
+    ]);
+    const newA = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newA?.cards).toEqual([fire5]);
+  });
+
+  it('matches the first joker in hand for a Joker play', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [joker, fire5],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, joker),
+      play(2 as NumberToken, wood4),
+    ]);
+    const newA = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newA?.cards).toEqual([fire5]);
+    expect(out.state.graveyard).toContainEqual(joker);
+  });
+
+  it('throws when a played card is not in the team hand', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [], // empty hand
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood4],
+    });
+    const s = stateWith([teamA, teamB]);
+    expect(() =>
+      resolveBattlePhase(s, [
+        play(1 as NumberToken, fire5),
+        play(2 as NumberToken, wood4),
+      ]),
+    ).toThrow(/not in hand/);
+  });
+
+  it('throws when an unknown team is referenced', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA]);
+    expect(() =>
+      resolveBattlePhase(s, [play(99 as NumberToken, fire5)]),
+    ).toThrow(/Team 99 not on grid/);
+  });
+
+  it('null (forfeit) play does not touch hand or graveyard', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [],
+    });
+    const s = stateWith([teamA, teamB]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, null),
+      play(2 as NumberToken, null),
+    ]);
+    const newA = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newA?.cards).toEqual([fire5]);
+    expect(out.state.graveyard ?? []).toEqual([]);
   });
 });

--- a/packages/core/src/logic/battle.ts
+++ b/packages/core/src/logic/battle.ts
@@ -1,4 +1,4 @@
-import type { Card } from '../types/card.ts';
+import type { Card, Deck } from '../types/card.ts';
 import type { Grid, GridCoord, PlayerState, TeamState } from '../types/grid.ts';
 import { ELEMENT_AXIS, isAdjacent, isSameCoord } from '../types/grid.ts';
 import type { TeamId } from '../types/token.ts';
@@ -186,20 +186,95 @@ function updateTeamInGrid(grid: Grid, updated: TeamState): Grid {
 }
 
 /**
+ * Locates the first card in `hand` matching `played` by structural
+ * equality (Joker matches any joker; ElementCard matches identical
+ * element and value). Returns -1 when no match exists.
+ */
+function findHandCardIndex(hand: Deck, played: Card): number {
+  if (played.kind === 'joker') {
+    return hand.findIndex((c) => c.kind === 'joker');
+  }
+  return hand.findIndex(
+    (c) =>
+      c.kind === 'element' &&
+      c.element === played.element &&
+      c.value === played.value,
+  );
+}
+
+function describeCard(card: Card): string {
+  return card.kind === 'joker' ? 'Joker' : `${card.element} ${card.value}`;
+}
+
+/**
+ * Pre-resolution gate: each non-null play must reference a card
+ * actually held in that team's hand. Throws RangeError with a
+ * descriptive message on the first violation so the simulator
+ * surfaces caller bugs immediately. Cards-not-on-grid teams also
+ * throw.
+ */
+function validatePlays(grid: Grid, plays: readonly BattlePlay[]): void {
+  for (const play of plays) {
+    if (play.card === null) continue;
+    const team = allTeams(grid).find((t) => t.teamNumber === play.teamId);
+    if (team === undefined) {
+      throw new RangeError(
+        `Team ${play.teamId} not on grid; cannot play ${describeCard(play.card)}.`,
+      );
+    }
+    if (findHandCardIndex(team.cards, play.card) === -1) {
+      throw new RangeError(
+        `Team ${play.teamId} cannot play ${describeCard(play.card)}: not in hand.`,
+      );
+    }
+  }
+}
+
+/**
+ * Removes the first card matching `played` from `team.cards` and
+ * returns the updated team plus the removed card (which the caller
+ * appends to the graveyard). When no match exists (e.g. validation
+ * was bypassed), the team is returned unchanged and the played
+ * card is reported as the consumed card.
+ */
+function consumeFromHand(
+  team: TeamState,
+  played: Card,
+): { team: TeamState; consumed: Card } {
+  const idx = findHandCardIndex(team.cards, played);
+  if (idx === -1) {
+    return { team, consumed: played };
+  }
+  const consumed = team.cards[idx] as Card;
+  const cards = [...team.cards.slice(0, idx), ...team.cards.slice(idx + 1)];
+  return { team: { ...team, cards }, consumed };
+}
+
+/**
  * Resolves the battle phase end-to-end:
+ * - Validates that every non-null play references a card the team
+ *   actually holds in hand (throws RangeError otherwise).
  * - Compute encounter order via {@link orderEncounters}.
- * - For each encounter pair, take the played card (or `null` for
- *   card absence), determine the winner via `resolveCards`, compute
- *   damage via `calcDamage` (joker/absence → fixed 1), then apply
- *   damage to the loser, drop tokens at the loser's coordinate, and
- *   remove the team from the grid when all players are eliminated.
- * - Returns the updated state (with a refreshed `droppedLifeTokens`
- *   map) and the full enriched `BattleResult[]`.
+ * - For each encounter, removes the played cards from the
+ *   participating teams' hands and appends them to
+ *   `state.graveyard` BEFORE damage resolution (so the
+ *   pre-damage hand snapshot only contains remaining cards). For
+ *   eliminated teams the played card still lands in the
+ *   graveyard.
+ * - Then determines the winner via `resolveCards`, computes
+ *   damage via `calcDamage` (joker/absence → fixed 1), applies
+ *   damage to the loser, drops tokens at the loser's
+ *   coordinate, and removes the team from the grid when all
+ *   players are eliminated.
+ * - Returns the updated state (refreshed `droppedLifeTokens` and
+ *   `graveyard`) and the full enriched `BattleResult[]`.
  */
 export function resolveBattlePhase(
   state: RoundState,
   plays: readonly BattlePlay[],
 ): { readonly state: RoundState; readonly results: readonly BattleResult[] } {
+  validatePlays(state.grid, plays);
+
   const encounters = orderEncounters(state);
   const playMap = new Map<TeamId, Card | null>();
   for (const play of plays) {
@@ -208,11 +283,12 @@ export function resolveBattlePhase(
 
   let grid = state.grid;
   let droppedLifeTokens = state.droppedLifeTokens ?? createEmptyDroppedTokens();
+  let graveyard: readonly Card[] = state.graveyard ?? [];
   const results: BattleResult[] = [];
 
   for (const enc of encounters) {
-    const teamA = findTeam(grid, enc.teamA);
-    const teamB = findTeam(grid, enc.teamB);
+    let teamA = findTeam(grid, enc.teamA);
+    let teamB = findTeam(grid, enc.teamB);
     if (teamA === undefined || teamB === undefined) {
       results.push({ ...enc, winner: null, damage: 0 });
       continue;
@@ -224,6 +300,23 @@ export function resolveBattlePhase(
     const cardB = playMap.has(enc.teamB)
       ? (playMap.get(enc.teamB) as Card | null)
       : null;
+
+    // Consume played cards from each team's hand BEFORE damage
+    // resolution. Both teams retain the rest of their hand for
+    // potential post-encounter operations (e.g. forfeit on
+    // elimination — #110).
+    if (cardA !== null) {
+      const cons = consumeFromHand(teamA, cardA);
+      teamA = cons.team;
+      graveyard = [...graveyard, cons.consumed];
+      grid = updateTeamInGrid(grid, teamA);
+    }
+    if (cardB !== null) {
+      const cons = consumeFromHand(teamB, cardB);
+      teamB = cons.team;
+      graveyard = [...graveyard, cons.consumed];
+      grid = updateTeamInGrid(grid, teamB);
+    }
 
     let winnerId: TeamId | null = null;
     let damage = 0;
@@ -271,7 +364,7 @@ export function resolveBattlePhase(
   }
 
   return {
-    state: { ...state, grid, droppedLifeTokens },
+    state: { ...state, grid, droppedLifeTokens, graveyard },
     results,
   };
 }

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -12,7 +12,7 @@ import type { InputProvider, RoundInputs } from './runner.ts';
 import { runRound, runUntilGameOver } from './runner.ts';
 import { setupGame } from './setup.ts';
 
-const fire1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
+const _fire1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
 const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
 const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
 const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
@@ -60,6 +60,7 @@ function makeTeam(opts: {
   life?: number;
   members?: 1 | 2;
   gridCards?: readonly [Card, Card];
+  cards?: readonly Card[];
 }): TeamState {
   const life = opts.life ?? 4;
   const members = opts.members ?? 1;
@@ -71,7 +72,7 @@ function makeTeam(opts: {
     teamNumber: opts.id,
     position: opts.position,
     facing: 'north',
-    cards: [],
+    cards: opts.cards ?? [],
     players,
     ...(opts.gridCards ? { gridCards: opts.gridCards } : {}),
   };
@@ -129,12 +130,14 @@ describe('runRound', () => {
       position: fireWater,
       life: 4,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
       position: fireWater,
       life: 4,
       gridCards: [wood1, wood4],
+      cards: [wood4],
     });
     const s = stateWith([teamA, teamB], deckOfTriples([[wood1, wood1, fire5]]));
     const out = runRound(
@@ -264,12 +267,14 @@ describe('runRound', () => {
       position: fireWater,
       life: 4,
       gridCards: [fire5, water3],
+      cards: [fire5],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
       position: fireWater,
       life: 1,
       gridCards: [wood1, wood4],
+      cards: [wood4],
     });
     const s = stateWith([teamA, teamB], deckOfTriples([[wood1, wood1, fire5]]));
     const out = runRound(
@@ -324,17 +329,22 @@ describe('runRound', () => {
 
 describe('runUntilGameOver', () => {
   it('terminates within maxRounds and returns winner', () => {
+    // Team A plays Joker every round; Team B plays wood4. Joker
+    // always wins → 1 damage/round. Team B has 2 life → eliminated
+    // in round 2. Hands sized for 2 rounds of consumption.
     const teamA = makeTeam({
       id: 1 as NumberToken,
       position: fireWater,
       life: 4,
       gridCards: [fire5, water3],
+      cards: [joker, joker],
     });
     const teamB = makeTeam({
       id: 2 as NumberToken,
       position: fireWater,
       life: 2,
       gridCards: [wood1, wood4],
+      cards: [wood4, wood4],
     });
     // Plenty of deck for up to 10 rounds × 3 draws each.
     const deck = Array.from({ length: 30 }, (_, i) =>
@@ -399,26 +409,16 @@ describe('runUntilGameOver', () => {
     expect((initial.deck ?? []).length).toBeGreaterThan(0);
     const teamIds = allTeams(initial).map((t) => t.teamNumber);
     expect(teamIds.length).toBe(2);
-    // Scripted: each team always plays a joker (always wins or draws)
-    const provider: InputProvider = (state) => {
-      const teams = allTeams(state);
-      return {
-        battle: {
-          plays: teams.map((t) => ({
-            teamId: t.teamNumber,
-            card: joker as Card,
-          })),
-        },
-        movement: {
-          teamMoves: teams.map((t) => ({
-            teamId: t.teamNumber,
-            card: fire1 as Card,
-            intendedFacing: t.facing,
-          })),
-        },
-        revival: { choices: new Map() },
-      };
-    };
+    // Scripted: each team forfeits (null play) so the game cannot
+    // end via battle. The provider doesn't need to know team hands.
+    // Movement also passes null-equivalent (no moves submitted).
+    const provider: InputProvider = () => ({
+      battle: {
+        plays: teamIds.map((id) => ({ teamId: id, card: null })),
+      },
+      movement: { teamMoves: [] },
+      revival: { choices: new Map() },
+    });
     const result = runUntilGameOver(initial, provider, 30);
     expect(result.rounds).toBeGreaterThan(0);
   });


### PR DESCRIPTION
Closes #109 · Refs roadmap #107

Wave-5 step 2: enforces that battle plays come from a team's hand
and consumes them to the graveyard. Until now \`BattlePlay.card\`
was accepted unconditionally regardless of hand contents.

## Summary

- Pre-resolution **validation gate** in \`resolveBattlePhase\`:
  every non-null play must reference a card the team actually
  holds (structural equality — jokers match any joker; element
  cards match \`element\` + \`value\`). Throws \`RangeError\` on the
  first violation, with a descriptive message naming the team and
  card.
- **Consumption**: for each encounter, the played card is removed
  from the team's hand and appended to \`state.graveyard\` BEFORE
  damage resolution. Both winners and losers (including those
  about to be eliminated) get their played card consumed — this
  matches rules.ja.md §Battle 10 ("revealed card discarded to
  graveyard"). The remaining hand (sans played card) is what
  follow-up #110 will seize from on elimination.
- **Hand semantics**: first-match removal (deterministic) for
  duplicates; Joker plays match the first joker in hand;
  \`null\` plays touch nothing.
- Existing battle and runner tests updated to populate
  \`team.cards\` with the cards they play.

## Test plan

- [x] \`pnpm run test\` — 171 tests pass (7 new for #109)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome + markdown + cspell all clean
- [x] Consumption: removes 1 card; duplicates only lose one; joker matches first joker; graveyard receives the consumed card
- [x] Validation: unknown team → throws; card not in hand → throws; null play → no touch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Battle system now validates that only cards in hand can be played.
  * Played cards are properly removed from hand and tracked in graveyard.
  * Enhanced error handling for invalid card plays and team references.

* **Tests**
  * Expanded test coverage for hand consumption and card validation in battle resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->