### PR TITLE
feat(core): swap one grid-card per team during movement phase

### DIFF
--- a/packages/core/src/logic/round.test.ts
+++ b/packages/core/src/logic/round.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import type { ElementCard } from '../types/card.ts';
+import type { ElementCard, JokerCard } from '../types/card.ts';
 import type { Facing, GridCoord, TeamState } from '../types/grid.ts';
 import type { LifeToken, NumberToken } from '../types/token.ts';
+import { createLifeToken } from '../types/token.ts';
 import type { RoundState } from './round.ts';
 import {
   advanceBattle,
@@ -271,6 +272,140 @@ describe('advanceMovement — forbidden cell penalty', () => {
     ]);
     expect(next.grid.fire.water).toHaveLength(0);
     expect(next.droppedLifeTokens?.fire.water).toBe(1);
+  });
+});
+
+describe('advanceMovement — grid-card swap', () => {
+  const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+  const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+  const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+
+  it('swaps gridCards[0] with the played card by default', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1],
+      players: [{ life: createLifeToken(2) }],
+      gridCards: [fire5, water3],
+    };
+    const s = stateWith([team]);
+    const next = advanceMovement(s, 'fire', [
+      {
+        teamId: 1 as NumberToken,
+        card: wood1,
+        intendedFacing: 'east',
+      },
+    ]);
+    const newTeam = next.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newTeam?.gridCards).toEqual([wood1, water3]);
+    expect(newTeam?.cards).toEqual([]);
+    expect(next.graveyard).toContainEqual(fire5);
+  });
+
+  it('swaps gridCards[1] when gridSwapIndex = 1', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1],
+      players: [{ life: createLifeToken(2) }],
+      gridCards: [fire5, water3],
+    };
+    const s = stateWith([team]);
+    const next = advanceMovement(s, 'fire', [
+      {
+        teamId: 1 as NumberToken,
+        card: wood1,
+        intendedFacing: 'east',
+        gridSwapIndex: 1,
+      },
+    ]);
+    const newTeam = next.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newTeam?.gridCards).toEqual([fire5, wood1]);
+    expect(next.graveyard).toContainEqual(water3);
+  });
+
+  it('removes played card from hand', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1, fire5],
+      players: [{ life: createLifeToken(2) }],
+      gridCards: [fire5, water3],
+    };
+    const s = stateWith([team]);
+    const next = advanceMovement(s, 'fire', [
+      {
+        teamId: 1 as NumberToken,
+        card: wood1,
+        intendedFacing: 'east',
+      },
+    ]);
+    const newTeam = next.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newTeam?.cards).toEqual([fire5]);
+  });
+
+  it('joker swap works', () => {
+    const joker: JokerCard = { kind: 'joker' };
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [joker],
+      players: [{ life: createLifeToken(2) }],
+      gridCards: [fire5, water3],
+    };
+    const s = stateWith([team]);
+    // Joker is a movement card → team moves forward (north). New
+    // position after stepForward('fire-water', 'north') is fire-wood.
+    const next = advanceMovement(s, 'water', [
+      {
+        teamId: 1 as NumberToken,
+        card: joker,
+        intendedFacing: 'east',
+      },
+    ]);
+    const newTeam = next.grid.fire.wood.find((t) => t.teamNumber === 1);
+    expect(newTeam?.gridCards?.[0]).toEqual(joker);
+    expect(next.graveyard).toContainEqual(fire5);
+  });
+
+  it('throws when played card is not in team hand (and team has gridCards)', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [],
+      players: [{ life: createLifeToken(2) }],
+      gridCards: [fire5, water3],
+    };
+    const s = stateWith([team]);
+    expect(() =>
+      advanceMovement(s, 'fire', [
+        {
+          teamId: 1 as NumberToken,
+          card: wood1,
+          intendedFacing: 'east',
+        },
+      ]),
+    ).toThrow(/not in hand/);
+  });
+
+  it('legacy team without gridCards: no swap, no hand validation', () => {
+    const team = makeTeam(1 as NumberToken, fireWater, 'north');
+    const s = stateWith([team]);
+    const next = advanceMovement(s, 'fire', [
+      {
+        teamId: 1 as NumberToken,
+        card: wood1,
+        intendedFacing: 'east',
+      },
+    ]);
+    const newTeam = next.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newTeam?.gridCards).toBeUndefined();
+    expect(next.graveyard ?? []).toEqual([]);
   });
 });
 

--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -91,6 +91,13 @@ export type TeamMove = {
   readonly card: Card;
   /** Facing the team chose when presenting the card (step 3 of movement). */
   readonly intendedFacing: Facing;
+  /**
+   * Which of the team's two `gridCards` slots to replace with `card`
+   * after movement is applied (rules.ja.md §Movement 6). Defaults to
+   * slot 0 when omitted. Ignored for teams that have no `gridCards`
+   * (legacy state).
+   */
+  readonly gridSwapIndex?: 0 | 1;
 };
 
 /** Returns a blank 3×3 grid with no teams. */
@@ -287,15 +294,62 @@ function removeTeamFromGrid(grid: Grid, team: TeamState): Grid {
 }
 
 /**
+ * Locates the first card in `hand` matching `played` by structural
+ * equality (Joker matches any joker; ElementCard matches identical
+ * element + value). Returns -1 when no match exists.
+ */
+function findMoveCardIndex(hand: Deck, played: Card): number {
+  if (played.kind === 'joker') {
+    return hand.findIndex((c) => c.kind === 'joker');
+  }
+  return hand.findIndex(
+    (c) =>
+      c.kind === 'element' &&
+      c.element === played.element &&
+      c.value === played.value,
+  );
+}
+
+function describeMoveCard(card: Card): string {
+  return card.kind === 'joker' ? 'Joker' : `${card.element} ${card.value}`;
+}
+
+/**
+ * Pre-validation: every move whose team has `gridCards` must
+ * reference a card in that team's hand. Legacy teams without
+ * `gridCards` skip validation (and the swap below). Throws
+ * RangeError on the first violation.
+ */
+function validateMoves(grid: Grid, teamMoves: readonly TeamMove[]): void {
+  for (const move of teamMoves) {
+    const team = findTeam(grid, move.teamId);
+    if (team === undefined) continue;
+    if (team.gridCards === undefined) continue;
+    if (findMoveCardIndex(team.cards, move.card) === -1) {
+      throw new RangeError(
+        `Team ${move.teamId} cannot play ${describeMoveCard(move.card)} for movement: not in hand.`,
+      );
+    }
+  }
+}
+
+/**
  * Processes the movement phase. For each team that revealed a card:
  * - If card element matches movementAttribute (or is a joker): move
  *   the team one cell in its current facing direction (off-grid is
  *   prevented by `stepForward` which clamps to the edge).
  * - Otherwise: update the team's facing to intendedFacing.
  *
- * After all moves, applies the forbidden-cell penalty per
- * rules.ja.md §Movement 7: any team whose new position is on a
- * forbidden cell loses 1 life token (lowest-life player charged
+ * After the move/rotate, when the team has `gridCards`:
+ * - Remove the played card from the team's hand.
+ * - Replace `gridCards[gridSwapIndex]` (default 0) with the played card.
+ * - Append the displaced grid card to `state.graveyard`.
+ *
+ * Teams without `gridCards` (legacy state) skip the swap silently.
+ *
+ * After all moves and swaps, applies the forbidden-cell penalty
+ * per rules.ja.md §Movement 7: any team whose new position is on
+ * a forbidden cell loses 1 life token (lowest-life player charged
  * first). Self-elimination via penalty removes the team from the
  * grid but does not trigger card theft.
  *
@@ -307,6 +361,9 @@ export function advanceMovement(
   teamMoves: readonly TeamMove[],
 ): RoundState {
   let grid = state.grid;
+  let graveyard: readonly Card[] = state.graveyard ?? [];
+
+  validateMoves(grid, teamMoves);
 
   for (const move of teamMoves) {
     const team = findTeam(grid, move.teamId);
@@ -322,6 +379,30 @@ export function advanceMovement(
       updated = { ...team, position: newPos };
     } else {
       updated = { ...team, facing: move.intendedFacing };
+    }
+
+    // Apply grid-card swap when the team has positioned cards.
+    if (team.gridCards !== undefined) {
+      const handIdx = findMoveCardIndex(team.cards, move.card);
+      if (handIdx !== -1) {
+        const newHand = [
+          ...team.cards.slice(0, handIdx),
+          ...team.cards.slice(handIdx + 1),
+        ];
+        const slot: 0 | 1 = move.gridSwapIndex ?? 0;
+        const oldGridCard = team.gridCards[slot] as Card;
+        const newGridCards: [Card, Card] = [
+          team.gridCards[0],
+          team.gridCards[1],
+        ];
+        newGridCards[slot] = move.card;
+        graveyard = [...graveyard, oldGridCard];
+        updated = {
+          ...updated,
+          cards: newHand,
+          gridCards: newGridCards,
+        };
+      }
     }
 
     grid = replaceTeamInGrid(grid, team.position, updated);
@@ -346,7 +427,7 @@ export function advanceMovement(
       : replaceTeamInGrid(grid, team.position, damagedTeam);
   }
 
-  return { ...state, phase: 'revival', grid, droppedLifeTokens };
+  return { ...state, phase: 'revival', grid, droppedLifeTokens, graveyard };
 }
 
 /** A team's chosen recovery action when a dropped token is salvageable. */


### PR DESCRIPTION
Closes #111 · Refs roadmap #107

Wave-5 step 3: implements the rules.ja.md §Movement 6 grid-card
swap that wave-4 left out. After each round's movement, every
team replaces one of their two \`gridCards\` with the card just
played, discarding the old card to \`state.graveyard\`. This
evolves a team's piece composition and shifts pair-sum encounter
ordering for the next round.

## Summary

- \`TeamMove\` gains optional \`gridSwapIndex: 0 | 1\` (default \`0\`)
  so callers pick which grid slot to replace.
- Pre-validation in \`advanceMovement\` mirrors #109: each move's
  card must be in the team's hand. Throws \`RangeError\` on missing.
  Teams without \`gridCards\` (legacy state) skip validation AND
  swap silently — backward compatible with wave-4 fixtures.
- Played card removed from hand (first-match removal). New
  \`gridCards[slot]\` is the played card; old slot card pushed to
  \`state.graveyard\`.
- Order: validate → for each move: apply move/rotate → swap →
  forbidden-cell penalty on post-swap state.

## Test plan

- [x] \`pnpm run test\` — 170 tests pass (6 new for grid-card swap)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome + markdown + cspell all clean
- [x] Default slot 0, explicit slot 1, hand removal, joker swap, hand-validation throw, legacy-skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added grid-card swapping mechanics during team movement
  * Players can now select which grid position to update when playing movement cards
  * Enhanced card management with automatic graveyard handling for displaced cards

* **Tests**
  * Added comprehensive test coverage for grid-card swapping behavior and error conditions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->