### PR TITLE
feat(core): deck-draw bonuses on revival actions

### DIFF
--- a/packages/core/src/logic/round.test.ts
+++ b/packages/core/src/logic/round.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { ElementCard, JokerCard } from '../types/card.ts';
+import type { Card, ElementCard, JokerCard } from '../types/card.ts';
 import type { Facing, GridCoord, TeamState } from '../types/grid.ts';
 import type { LifeToken, NumberToken } from '../types/token.ts';
 import { createLifeToken } from '../types/token.ts';
@@ -523,5 +523,118 @@ describe('advanceRevival', () => {
     const next = advanceRevival(s, choices);
     const t = next.grid.fire.water.find((tm) => tm.teamNumber === 1);
     expect(t?.players[0]?.life).toBe(2); // unchanged
+  });
+});
+
+describe('advanceRevival — deck-draw bonuses', () => {
+  const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+  const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+  const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+
+  function stateWithDeck(
+    team: TeamState,
+    deck: Card[],
+    dropped = 1,
+  ): RoundState {
+    const base = stateWith([team]);
+    return {
+      ...base,
+      phase: 'revival',
+      droppedLifeTokens: {
+        fire: { fire: 0, water: dropped, wood: 0 },
+        water: { fire: 0, water: 0, wood: 0 },
+        wood: { fire: 0, water: 0, wood: 0 },
+      },
+      deck,
+    };
+  }
+
+  it('revive-member draws 1 bonus card from deck into hand', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1],
+      players: [{ life: 0 as LifeToken }, { life: 3 as LifeToken }],
+    };
+    const s = stateWithDeck(team, [fire5, water3]);
+    const next = advanceRevival(
+      s,
+      new Map([[1 as NumberToken, { type: 'revive-member' }]]),
+    );
+    const t = next.grid.fire.water.find((tm) => tm.teamNumber === 1);
+    expect(t?.players[0]?.life).toBe(1); // revived
+    expect(t?.cards).toEqual([wood1, fire5]); // bonus draw appended
+    expect(next.deck).toEqual([water3]); // 1 popped
+  });
+
+  it('charge-cards draws 3 cards from deck into hand', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1],
+      players: [{ life: 2 as LifeToken }],
+    };
+    const s = stateWithDeck(team, [fire5, water3, wood1, fire5]);
+    const next = advanceRevival(
+      s,
+      new Map([[1 as NumberToken, { type: 'charge-cards' }]]),
+    );
+    const t = next.grid.fire.water.find((tm) => tm.teamNumber === 1);
+    expect(t?.cards).toEqual([wood1, fire5, water3, wood1]);
+    expect(next.deck).toEqual([fire5]); // 3 popped
+  });
+
+  it('charge-life does NOT touch deck', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [],
+      players: [{ life: 2 as LifeToken }],
+    };
+    const s = stateWithDeck(team, [fire5, water3]);
+    const next = advanceRevival(
+      s,
+      new Map([[1 as NumberToken, { type: 'charge-life' }]]),
+    );
+    expect(next.deck).toEqual([fire5, water3]); // unchanged
+  });
+
+  it('empty deck on revive-member: revive happens, hand unchanged', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [wood1],
+      players: [{ life: 0 as LifeToken }, { life: 3 as LifeToken }],
+    };
+    const s = stateWithDeck(team, []);
+    const next = advanceRevival(
+      s,
+      new Map([[1 as NumberToken, { type: 'revive-member' }]]),
+    );
+    const t = next.grid.fire.water.find((tm) => tm.teamNumber === 1);
+    expect(t?.players[0]?.life).toBe(1); // revived
+    expect(t?.cards).toEqual([wood1]); // no bonus draw
+  });
+
+  it('partial draw on charge-cards when deck has fewer than 3 cards', () => {
+    const team: TeamState = {
+      teamNumber: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      cards: [],
+      players: [{ life: 2 as LifeToken }],
+    };
+    const s = stateWithDeck(team, [fire5, water3]);
+    const next = advanceRevival(
+      s,
+      new Map([[1 as NumberToken, { type: 'charge-cards' }]]),
+    );
+    const t = next.grid.fire.water.find((tm) => tm.teamNumber === 1);
+    expect(t?.cards).toEqual([fire5, water3]); // 2 drawn
+    expect(next.deck).toEqual([]);
   });
 });

--- a/packages/core/src/logic/round.ts
+++ b/packages/core/src/logic/round.ts
@@ -439,6 +439,22 @@ export type RevivalAction =
 const REVIVAL_LIFE_CAP = 4;
 
 /**
+ * Pops up to `count` cards from the front of `deck` and returns
+ * the drawn portion plus the remaining deck. If `deck` has fewer
+ * cards than `count`, returns however many are available (no
+ * throw — gracefully degrade).
+ */
+function drawCardsFromDeck(
+  deck: Deck | undefined,
+  count: number,
+): { drawn: readonly Card[]; remaining: Deck } {
+  const source = deck ?? [];
+  const drawn = source.slice(0, count);
+  const remaining = source.slice(count);
+  return { drawn, remaining };
+}
+
+/**
  * Advances from revival to the next round's battle phase.
  *
  * For each surviving team whose current coordinate has at least one
@@ -446,11 +462,13 @@ const REVIVAL_LIFE_CAP = 4;
  * (v1 eligibility rule — refine via playtest if needed), apply the
  * caller-provided RevivalAction:
  *
- * - **`revive-member`**: restore one eliminated player (life 0 → 1).
- *   Bonus card draw not yet modelled (pending card-economy work).
+ * - **`revive-member`**: restore one eliminated player (life 0 → 1)
+ *   and draw 1 bonus card from `state.deck` into the team's hand
+ *   when available (rules.ja.md §Revival 2).
  * - **`charge-life`**: add 1 life to the lowest-life living player,
- *   clamped to 4. Skip when no eligible player.
- * - **`charge-cards`**: no-op in v1 (deck-draw not yet modelled).
+ *   clamped to 4. No deck draw. Skip when no eligible player.
+ * - **`charge-cards`**: draw 3 cards from `state.deck` into the
+ *   team's hand. Partial draw when fewer cards remain.
  *
  * Each consumed action decrements `droppedLifeTokens` at the team's
  * coordinate by 1. Phase advances to `'battle'` and round number
@@ -462,6 +480,7 @@ export function advanceRevival(
 ): RoundState {
   let grid = state.grid;
   let droppedLifeTokens = state.droppedLifeTokens ?? createEmptyDroppedTokens();
+  let deck: Deck = state.deck ?? [];
 
   for (const team of allTeams(grid)) {
     if (!isTeamAliveTeam(team)) continue;
@@ -486,7 +505,14 @@ export function advanceRevival(
         const newPlayers = team.players.map((p, i) =>
           i === idx ? { life: createLifeToken(1) } : p,
         );
-        updatedTeam = { ...team, players: newPlayers };
+        // Bonus: draw 1 card from the deck into the team's hand.
+        const draw = drawCardsFromDeck(deck, 1);
+        deck = draw.remaining;
+        updatedTeam = {
+          ...team,
+          players: newPlayers,
+          cards: [...team.cards, ...draw.drawn],
+        };
         consumed = true;
         break;
       }
@@ -510,7 +536,13 @@ export function advanceRevival(
         break;
       }
       case 'charge-cards': {
-        // No-op in v1: deck-draw protocol not yet modelled.
+        // Draw 3 cards (or however many remain) from the deck.
+        const draw = drawCardsFromDeck(deck, 3);
+        deck = draw.remaining;
+        updatedTeam = {
+          ...team,
+          cards: [...team.cards, ...draw.drawn],
+        };
         consumed = true;
         break;
       }
@@ -529,6 +561,7 @@ export function advanceRevival(
     round: state.round + 1,
     grid,
     droppedLifeTokens,
+    deck,
   };
 }
 


### PR DESCRIPTION
Closes #112 · Refs roadmap #107

Wave-5 step 4: replaces the v1 no-op handling of the deck-draw
bonuses on revival with the real rules from rules.ja.md §Revival 2.

## Summary

- **\`revive-member\`** — restores eliminated player to life 1
  (unchanged) AND now draws 1 bonus card from \`state.deck\`
  into the team's hand. Empty deck → revival happens, no bonus.
- **\`charge-cards\`** — draws up to 3 cards from \`state.deck\`
  into the team's hand. Previously a no-op. Partial draw when
  the deck has fewer than 3 cards.
- **\`charge-life\`** — unchanged (no deck-draw, just +1 life
  with cap-at-4).

\`state.deck\` shrinks by however many cards each action
consumes. All cases handled gracefully without throws.

## Test plan

- [x] \`pnpm run test\` — 169 tests pass (5 new for deck-draw)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome + markdown + cspell all clean
- [x] revive-member bonus draw; charge-cards full draw;
      charge-life no-touch; empty-deck revive (no bonus);
      partial charge-cards (fewer than 3 in deck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced revival phase with strategic card draw bonuses—reviving members grants 1 bonus card, while charging cards draws up to 3 cards from the deck, providing improved mid-game recovery options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->