### PR TITLE
feat(core): card forfeit on team elimination + E× overflow damage

### DIFF
--- a/packages/core/src/logic/battle.test.ts
+++ b/packages/core/src/logic/battle.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import type { GameConfig } from '../config.ts';
+import { DEFAULT_CONFIG } from '../config.ts';
 import type { Card, ElementCard, JokerCard } from '../types/card.ts';
 import type { Facing, Grid, GridCoord, TeamState } from '../types/grid.ts';
 import type { NumberToken } from '../types/token.ts';
@@ -658,5 +660,185 @@ describe('resolveBattlePhase — hand consumption + validation', () => {
     const newA = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
     expect(newA?.cards).toEqual([fire5]);
     expect(out.state.graveyard ?? []).toEqual([]);
+  });
+});
+
+describe('resolveBattlePhase — forfeit on elimination', () => {
+  function play(teamId: NumberToken, card: Card | null): BattlePlay {
+    return { teamId, card };
+  }
+
+  // wood2 not in the shared constants — declare locally.
+  const wood2: ElementCard = { kind: 'element', element: 'wood', value: 2 };
+
+  it('eliminated loser forfeits 1 card to the winner; remainder to graveyard', () => {
+    // Team A (life 4) beats Team B (life 1, eliminated). Loser hand
+    // has [wood2, fire5] AFTER the played card is consumed. Winner
+    // gets first card (wood2); fire5 goes to graveyard.
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 1,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood1, wood2, fire5],
+    });
+    const s = stateWith([winnerTeam, loser]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood1),
+    ]);
+    expect(out.results[0]?.winner).toBe(1);
+    // Winner gains 1 forfeit card (first remaining after consume)
+    const newWinner = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newWinner?.cards).toContainEqual(wood2);
+    // Remaining loser card → graveyard
+    expect(out.state.graveyard).toContainEqual(fire5);
+  });
+
+  it('overflow grants E× extra forfeit cards (default E=2)', () => {
+    // Loser has life=1, damage=3 → overflow=2 → forfeit=1+2*2=5
+    // Loser hand has 6 cards (after played card consumed, 5
+    // remaining). Winner takes 5; 0 to graveyard.
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire13, water3],
+      cards: [fire13],
+    });
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 1,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood1, fire5, wood2, water3, fire5, fire5],
+    });
+    const s = stateWith([winnerTeam, loser]);
+    // fire13 vs wood1: fire wins. damage = 1 base + 1 facing + 1 bonus = 3
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire13),
+      play(2 as NumberToken, wood1),
+    ]);
+    expect(out.results[0]?.damage).toBe(3);
+    // Loser life 1 → overflow=2 → forfeit=5
+    const newWinner = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    // Winner started with 0 in hand (played fire13). Gains 5 from
+    // loser. Loser played wood1 → remaining was 5 cards.
+    expect(newWinner?.cards.length).toBe(5);
+  });
+
+  it('survive (no elimination): no forfeit', () => {
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 4,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood1, fire5, wood2],
+    });
+    const s = stateWith([winnerTeam, loser]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood1),
+    ]);
+    expect(out.results[0]?.winner).toBe(1);
+    const newWinner = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    // Winner hand unchanged (no forfeit on survival)
+    expect(newWinner?.cards).toEqual([]);
+    // Loser still on grid with reduced life and unchanged remaining hand
+    const survivedLoser = out.state.grid.fire.water.find(
+      (t) => t.teamNumber === 2,
+    );
+    expect(survivedLoser?.cards).toEqual([fire5, wood2]);
+  });
+
+  it('elimination with empty loser hand: no transfer, no error', () => {
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 1,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood1], // single card, consumed during play
+    });
+    const s = stateWith([winnerTeam, loser]);
+    const out = resolveBattlePhase(s, [
+      play(1 as NumberToken, fire5),
+      play(2 as NumberToken, wood1),
+    ]);
+    const newWinner = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    // After consuming played fire5 the winner's hand is empty.
+    // Loser hand empty after consume, so 0 cards transferred.
+    expect(newWinner?.cards).toEqual([]);
+  });
+
+  it('config E controls overflow forfeit multiplier', () => {
+    // Override config with E=3 to verify the multiplier flows.
+    const customConfig: GameConfig = {
+      ...DEFAULT_CONFIG,
+      damageOverflowFactor: 3,
+    };
+    const winnerTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      facing: 'north',
+      life: 4,
+      members: 1,
+      gridCards: [fire13, water3],
+      cards: [fire13],
+    });
+    const loser = makeTeam({
+      id: 2 as NumberToken,
+      position: fireWater,
+      facing: 'south',
+      life: 1,
+      members: 1,
+      gridCards: [wood1, wood4],
+      cards: [wood1, fire5, fire5, fire5, fire5, fire5, fire5, fire5],
+    });
+    const s = stateWith([winnerTeam, loser]);
+    const out = resolveBattlePhase(
+      s,
+      [play(1 as NumberToken, fire13), play(2 as NumberToken, wood1)],
+      customConfig,
+    );
+    // damage 3, life 1 → overflow 2 → forfeit = 1 + 3*2 = 7
+    const newWinner = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(newWinner?.cards.length).toBe(7);
   });
 });

--- a/packages/core/src/logic/battle.ts
+++ b/packages/core/src/logic/battle.ts
@@ -1,3 +1,5 @@
+import type { GameConfig } from '../config.ts';
+import { DEFAULT_CONFIG } from '../config.ts';
 import type { Card, Deck } from '../types/card.ts';
 import type { Grid, GridCoord, PlayerState, TeamState } from '../types/grid.ts';
 import { ELEMENT_AXIS, isAdjacent, isSameCoord } from '../types/grid.ts';
@@ -251,27 +253,64 @@ function consumeFromHand(
 }
 
 /**
+ * Compute the loser's total remaining life before damage was applied.
+ */
+function totalLife(team: TeamState): number {
+  return team.players.reduce((sum, p) => sum + p.life, 0);
+}
+
+/**
+ * Per rules.ja.md §Battle 9: when a player is eliminated, the
+ * winner takes one card from the loser's hand; the rest go to the
+ * graveyard. When damage exceeds remaining life (overflow), the
+ * winner additionally takes `E × overflow` cards (E from
+ * `config.damageOverflowFactor`). v1 simplification: applies at the
+ * TEAM level (one forfeit per encounter) because the engine models
+ * encounters team-vs-team rather than per-player.
+ *
+ * The first `count` cards in `loser.cards` go to `winner.cards`;
+ * any remaining loser cards go to the graveyard. Returns the
+ * updated winner and the cards routed to graveyard.
+ */
+function applyForfeit(
+  loser: TeamState,
+  winner: TeamState,
+  count: number,
+): { winner: TeamState; toGraveyard: readonly Card[] } {
+  const safeCount = Math.max(0, Math.min(count, loser.cards.length));
+  const taken = loser.cards.slice(0, safeCount);
+  const remaining = loser.cards.slice(safeCount);
+  return {
+    winner: { ...winner, cards: [...winner.cards, ...taken] },
+    toGraveyard: remaining,
+  };
+}
+
+/**
  * Resolves the battle phase end-to-end:
  * - Validates that every non-null play references a card the team
  *   actually holds in hand (throws RangeError otherwise).
  * - Compute encounter order via {@link orderEncounters}.
  * - For each encounter, removes the played cards from the
  *   participating teams' hands and appends them to
- *   `state.graveyard` BEFORE damage resolution (so the
- *   pre-damage hand snapshot only contains remaining cards). For
- *   eliminated teams the played card still lands in the
+ *   `state.graveyard` BEFORE damage resolution.
+ * - Then determines the winner via `resolveCards`, computes damage
+ *   via `calcDamage` (joker/absence → fixed 1), applies damage to
+ *   the loser, drops tokens at the loser's coordinate.
+ * - When the damage eliminates the loser, the **winner team seizes
+ *   `1 + E × overflow` cards** from the loser's remaining hand
+ *   (E from `config.damageOverflowFactor`, overflow = `damage -
+ *   life-before-damage`). Any loser cards not seized go to the
  *   graveyard.
- * - Then determines the winner via `resolveCards`, computes
- *   damage via `calcDamage` (joker/absence → fixed 1), applies
- *   damage to the loser, drops tokens at the loser's
- *   coordinate, and removes the team from the grid when all
- *   players are eliminated.
+ * - Eliminated teams are removed from the grid; surviving losers
+ *   keep their remaining hand.
  * - Returns the updated state (refreshed `droppedLifeTokens` and
  *   `graveyard`) and the full enriched `BattleResult[]`.
  */
 export function resolveBattlePhase(
   state: RoundState,
   plays: readonly BattlePlay[],
+  config: GameConfig = DEFAULT_CONFIG,
 ): { readonly state: RoundState; readonly results: readonly BattleResult[] } {
   validatePlays(state.grid, plays);
 
@@ -303,8 +342,7 @@ export function resolveBattlePhase(
 
     // Consume played cards from each team's hand BEFORE damage
     // resolution. Both teams retain the rest of their hand for
-    // potential post-encounter operations (e.g. forfeit on
-    // elimination — #110).
+    // potential post-encounter operations (forfeit on elimination).
     if (cardA !== null) {
       const cons = consumeFromHand(teamA, cardA);
       teamA = cons.team;
@@ -349,7 +387,9 @@ export function resolveBattlePhase(
 
     if (winnerId === null || damage <= 0) continue;
 
+    const winnerTeam = winnerId === enc.teamA ? teamA : teamB;
     const loser = winnerId === enc.teamA ? teamB : teamA;
+    const lifeBeforeDamage = totalLife(loser);
     const { team: damagedLoser, tokensDropped } = applyDamage(loser, damage);
 
     droppedLifeTokens = addDroppedTokens(
@@ -358,9 +398,21 @@ export function resolveBattlePhase(
       tokensDropped,
     );
 
-    grid = isTeamDead(damagedLoser)
-      ? removeTeamFromGrid(grid, damagedLoser)
-      : updateTeamInGrid(grid, damagedLoser);
+    if (isTeamDead(damagedLoser)) {
+      // Elimination forfeit: winner takes 1 base card + E × overflow.
+      const overflow = Math.max(0, damage - lifeBeforeDamage);
+      const forfeitCount = 1 + config.damageOverflowFactor * overflow;
+      const { winner: enrichedWinner, toGraveyard } = applyForfeit(
+        damagedLoser,
+        winnerTeam,
+        forfeitCount,
+      );
+      graveyard = [...graveyard, ...toGraveyard];
+      grid = updateTeamInGrid(grid, enrichedWinner);
+      grid = removeTeamFromGrid(grid, damagedLoser);
+    } else {
+      grid = updateTeamInGrid(grid, damagedLoser);
+    }
   }
 
   return {


### PR DESCRIPTION
Closes #110 · Refs roadmap #107

Final wave-5 sub-issue: implements the rules.ja.md §Battle 9
card-forfeit cascade. When a team is eliminated, the winner takes
1 card; if damage overflowed remaining life, an extra \`E × overflow\`
cards are taken. Remaining loser cards go to \`state.graveyard\`.

## Summary

- \`resolveBattlePhase\` gains an optional \`config: GameConfig\`
  parameter (default \`DEFAULT_CONFIG\`).
- On elimination (loser's life reaches 0):
  - \`overflow = max(0, damage - life-before-damage)\`
  - \`forfeitCount = 1 + config.damageOverflowFactor × overflow\`
  - First \`forfeitCount\` cards from loser's remaining hand go to
    winner; the rest go to \`state.graveyard\`.
- No elimination → no forfeit.
- Empty loser hand → no transfer, no error.
- Custom config E multiplier flows through correctly.

## Test plan

- [x] \`pnpm run test\` — 176 tests pass (5 new for forfeit/overflow)
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome + markdown + cspell all clean
- [x] Elimination + 0 overflow → 1 card seized
- [x] Elimination + 2 overflow + E=2 (default) → 5 cards seized
- [x] Elimination + 2 overflow + E=3 (custom) → 7 cards seized
- [x] Survive (no elimination) → no forfeit
- [x] Empty loser hand at elimination → no transfer, no throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When a team is eliminated during battle, their remaining unplayed cards are now forfeited to the winner. The number of cards transferred is determined by the damage overflow (excess damage beyond the team's remaining life).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->