### PR TITLE
feat(core): add movement empty-hand draw fallback

### DIFF
--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -6,9 +6,9 @@ import { ELEMENT_AXIS } from '../types/grid.ts';
 import type { NumberToken, TeamId } from '../types/token.ts';
 import { createLifeToken } from '../types/token.ts';
 import type { BattlePlay } from './battle.ts';
-import type { RevivalAction, RoundState, TeamMove } from './round.ts';
+import type { RevivalAction, RoundState } from './round.ts';
 import { createEmptyGrid, isGameOver } from './round.ts';
-import type { InputProvider, RoundInputs } from './runner.ts';
+import type { InputProvider, MovementChoice, RoundInputs } from './runner.ts';
 import { runRound, runUntilGameOver } from './runner.ts';
 import { setupGame } from './setup.ts';
 
@@ -93,7 +93,7 @@ describe('runRound', () => {
   function makeInputs(
     opts: {
       plays?: readonly BattlePlay[];
-      teamMoves?: readonly TeamMove[];
+      teamMoves?: readonly MovementChoice[];
       revivalChoices?: ReadonlyMap<TeamId, RevivalAction>;
     } = {},
   ): RoundInputs {
@@ -238,6 +238,157 @@ describe('runRound', () => {
     expect(movementLogs.some((l) => l.message.includes('exhausted'))).toBe(
       true,
     );
+  });
+
+  it('draws 2 cards for an empty-hand team, uses 1 for movement, and keeps 1', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5, water3, fire5]);
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+      }),
+    );
+
+    const movedTeam = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(movedTeam?.facing).toBe('east');
+    expect(movedTeam?.cards).toEqual([fire5]);
+    expect(movedTeam?.gridCards).toEqual([water3, wood1]);
+    expect(out.state.graveyard).toContainEqual(wood4);
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'drew 2 card(s) for the empty-hand movement fallback',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('lets the caller pick which emergency-drawn card is used for movement', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [fire5, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [wood4, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, water3, fire5, wood4]);
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [
+          {
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+            emergencyDrawPick: 1,
+            gridSwapIndex: 1,
+          },
+        ],
+      }),
+    );
+
+    const movedTeam = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(movedTeam?.facing).toBe('east');
+    expect(movedTeam?.cards).toEqual([fire5]);
+    expect(movedTeam?.gridCards).toEqual([fire5, wood4]);
+    expect(out.state.graveyard).toContainEqual(wood1);
+    expect(out.state.deck).toEqual([]);
+  });
+
+  it('uses the only remaining deck card for empty-hand movement fallback', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5, water3]);
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+      }),
+    );
+
+    const movedTeam = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(movedTeam?.cards).toEqual([]);
+    expect(movedTeam?.gridCards).toEqual([water3, wood1]);
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'drew 1 card(s) for the empty-hand movement fallback',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps the round moving when empty-hand fallback cannot draw any cards', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5]);
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+      }),
+    );
+
+    const unchangedTeam = out.state.grid.fire.water.find(
+      (t) => t.teamNumber === 1,
+    );
+    expect(unchangedTeam?.facing).toBe('north');
+    expect(unchangedTeam?.cards).toEqual([]);
+    expect(unchangedTeam?.gridCards).toEqual([wood4, wood1]);
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'had no cards in hand and the deck was exhausted',
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('treats a drawn Joker as the fire-element fallback for forbidden coord', () => {

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -487,6 +487,75 @@ describe('runRound', () => {
     ).toBe(true);
   });
 
+  it('draws fallback cards but skips movement without an emergency-draw submission', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5, water3, fire5]);
+    const out = runRound(s, makeInputs());
+
+    const fallbackTeam = out.state.grid.fire.water.find(
+      (t) => t.teamNumber === 1,
+    );
+    expect(fallbackTeam?.facing).toBe('north');
+    expect(fallbackTeam?.cards).toEqual([water3, fire5]);
+    expect(fallbackTeam?.gridCards).toEqual([wood4, wood1]);
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'had no movement submission after the empty-hand movement fallback draw',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('uses the first remaining hand card when an emergency-draw choice survives battle with cards left', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [water3, fire5],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, wood1],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5]);
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [
+          {
+            kind: 'emergency-draw',
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+          },
+        ],
+      }),
+    );
+
+    const movedTeam = out.state.grid.fire.water.find((t) => t.teamNumber === 1);
+    expect(movedTeam?.facing).toBe('east');
+    expect(movedTeam?.cards).toEqual([fire5]);
+    expect(out.state.deck).toEqual([]);
+  });
+
   it('rejects explicit movement choices for empty-hand teams', () => {
     const teamA = makeTeam({
       id: 1 as NumberToken,

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -487,6 +487,44 @@ describe('runRound', () => {
     ).toBe(true);
   });
 
+  it('rejects explicit movement choices for empty-hand teams', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5, water3, fire5]);
+
+    expect(() =>
+      runRound(
+        s,
+        makeInputs({
+          teamMoves: [
+            {
+              kind: 'explicit',
+              teamId: 1 as NumberToken,
+              card: fire5,
+              intendedFacing: 'east',
+            },
+          ],
+        }),
+      ),
+    ).toThrowError(
+      new RangeError(
+        'Team 1 cannot use an explicit movement choice with an empty hand.',
+      ),
+    );
+  });
+
   it('treats a drawn Joker as the fire-element fallback for forbidden coord', () => {
     const teamA = makeTeam({
       id: 1 as NumberToken,

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -259,7 +259,13 @@ describe('runRound', () => {
     const out = runRound(
       s,
       makeInputs({
-        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+        teamMoves: [
+          {
+            kind: 'emergency-draw',
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+          },
+        ],
       }),
     );
 
@@ -276,6 +282,16 @@ describe('runRound', () => {
         ),
       ),
     ).toBe(true);
+    const movementAttributeIndex = out.log.findIndex(
+      (entry) => entry.message === 'Movement attribute: fire',
+    );
+    const emergencyDrawIndex = out.log.findIndex((entry) =>
+      entry.message.includes(
+        'drew 2 card(s) for the empty-hand movement fallback',
+      ),
+    );
+    expect(movementAttributeIndex).toBeGreaterThanOrEqual(0);
+    expect(emergencyDrawIndex).toBeGreaterThan(movementAttributeIndex);
   });
 
   it('lets the caller pick which emergency-drawn card is used for movement', () => {
@@ -299,6 +315,7 @@ describe('runRound', () => {
       makeInputs({
         teamMoves: [
           {
+            kind: 'emergency-draw',
             teamId: 1 as NumberToken,
             intendedFacing: 'east',
             emergencyDrawPick: 1,
@@ -314,6 +331,73 @@ describe('runRound', () => {
     expect(movedTeam?.gridCards).toEqual([fire5, wood4]);
     expect(out.state.graveyard).toContainEqual(wood1);
     expect(out.state.deck).toEqual([]);
+  });
+
+  it('draws for simultaneous empty-hand teams in ascending team-number order', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, wood1],
+      cards: [],
+    });
+    const s = stateWith(
+      [teamA, teamB],
+      [wood1, wood1, fire5, water3, fire5, wood4],
+    );
+    const out = runRound(
+      s,
+      makeInputs({
+        teamMoves: [
+          {
+            kind: 'emergency-draw',
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+          },
+          {
+            kind: 'emergency-draw',
+            teamId: 2 as NumberToken,
+            intendedFacing: 'south',
+            gridSwapIndex: 1,
+          },
+        ],
+      }),
+    );
+
+    const movedTeamA = out.state.grid.fire.water.find(
+      (t) => t.teamNumber === 1,
+    );
+    const movedTeamB = out.state.grid.water.water.find(
+      (t) => t.teamNumber === 2,
+    );
+    expect(movedTeamA?.cards).toEqual([fire5]);
+    expect(movedTeamA?.gridCards).toEqual([water3, wood1]);
+    expect(movedTeamB?.cards).toEqual([]);
+    expect(movedTeamB?.gridCards).toEqual([fire5, wood4]);
+    expect(out.state.graveyard).toContainEqual(wood4);
+    expect(out.state.graveyard).toContainEqual(wood1);
+    expect(out.state.deck).toEqual([]);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'Team 1 drew 2 card(s) for the empty-hand movement fallback',
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      out.log.some((entry) =>
+        entry.message.includes(
+          'Team 2 drew 1 card(s) for the empty-hand movement fallback',
+        ),
+      ),
+    ).toBe(true);
   });
 
   it('uses the only remaining deck card for empty-hand movement fallback', () => {
@@ -335,7 +419,13 @@ describe('runRound', () => {
     const out = runRound(
       s,
       makeInputs({
-        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+        teamMoves: [
+          {
+            kind: 'emergency-draw',
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+          },
+        ],
       }),
     );
 
@@ -371,7 +461,13 @@ describe('runRound', () => {
     const out = runRound(
       s,
       makeInputs({
-        teamMoves: [{ teamId: 1 as NumberToken, intendedFacing: 'east' }],
+        teamMoves: [
+          {
+            kind: 'emergency-draw',
+            teamId: 1 as NumberToken,
+            intendedFacing: 'east',
+          },
+        ],
       }),
     );
 

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -186,7 +186,8 @@ function resolveMovementChoices(
 
       const emergencyDraw = drawFromDeck(next.deck, 2);
       next = { ...next, deck: emergencyDraw.remaining };
-      if (emergencyDraw.drawn.length === 0) {
+      const [firstDrawnCard, secondDrawnCard] = emergencyDraw.drawn;
+      if (firstDrawnCard === undefined) {
         log.push({
           round,
           phase: 'movement',
@@ -203,11 +204,13 @@ function resolveMovementChoices(
       const selectedDrawIndex =
         choice?.kind === 'emergency-draw' ? (choice.emergencyDrawPick ?? 0) : 0;
       const selectedCard =
-        emergencyDraw.drawn[selectedDrawIndex] ?? emergencyDraw.drawn[0];
+        selectedDrawIndex === 1
+          ? (secondDrawnCard ?? firstDrawnCard)
+          : firstDrawnCard;
 
       resolvedMoves.push({
         teamId,
-        card: selectedCard as Card,
+        card: selectedCard,
         intendedFacing: choice?.intendedFacing ?? team.facing,
         ...(choice?.gridSwapIndex !== undefined
           ? { gridSwapIndex: choice.gridSwapIndex }

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -37,7 +37,9 @@ type EmergencyDrawMovementChoice = {
   /**
    * Optional emergency-draw pick for a hand-empty team. `0` chooses
    * the first drawn card, `1` the second. When omitted or unavailable,
-   * the runner falls back to the first drawn card.
+   * the runner falls back to the first drawn card. If battle-side
+   * card flow leaves cards in hand after input collection, the runner
+   * instead consumes the first remaining hand card heuristically.
    */
   readonly emergencyDrawPick?: 0 | 1;
 };
@@ -201,8 +203,21 @@ function resolveMovementChoices(
         cards: [...team.cards, ...emergencyDraw.drawn],
       };
       next = updateTeam(next, replenishedTeam);
-      const selectedDrawIndex =
-        choice?.kind === 'emergency-draw' ? (choice.emergencyDrawPick ?? 0) : 0;
+      log.push({
+        round,
+        phase: 'movement',
+        message: `Team ${teamId} drew ${emergencyDraw.drawn.length} card(s) for the empty-hand movement fallback`,
+      });
+      if (choice?.kind !== 'emergency-draw') {
+        log.push({
+          round,
+          phase: 'movement',
+          message: `Team ${teamId} had no movement submission after the empty-hand movement fallback draw`,
+        });
+        continue;
+      }
+
+      const selectedDrawIndex = choice.emergencyDrawPick ?? 0;
       const selectedCard =
         selectedDrawIndex === 1
           ? (secondDrawnCard ?? firstDrawnCard)
@@ -211,25 +226,28 @@ function resolveMovementChoices(
       resolvedMoves.push({
         teamId,
         card: selectedCard,
-        intendedFacing: choice?.intendedFacing ?? team.facing,
-        ...(choice?.gridSwapIndex !== undefined
+        intendedFacing: choice.intendedFacing,
+        ...(choice.gridSwapIndex !== undefined
           ? { gridSwapIndex: choice.gridSwapIndex }
           : {}),
-      });
-
-      log.push({
-        round,
-        phase: 'movement',
-        message: `Team ${teamId} drew ${emergencyDraw.drawn.length} card(s) for the empty-hand movement fallback`,
       });
       continue;
     }
 
     if (choice === undefined) continue;
-    if (choice.kind !== 'explicit') {
-      throw new RangeError(
-        `Team ${teamId} must use an explicit movement choice while cards remain in hand.`,
-      );
+    if (choice.kind === 'emergency-draw') {
+      const [firstHandCard] = team.cards;
+      if (firstHandCard === undefined) continue;
+
+      resolvedMoves.push({
+        teamId,
+        card: firstHandCard,
+        intendedFacing: choice.intendedFacing,
+        ...(choice.gridSwapIndex !== undefined
+          ? { gridSwapIndex: choice.gridSwapIndex }
+          : {}),
+      });
+      continue;
     }
 
     resolvedMoves.push({
@@ -339,7 +357,7 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
     log.push({
       round,
       phase: 'movement',
-      message: `Movement resolution: ${resolvedMovement.teamMoves.length} moves submitted`,
+      message: `Movement resolution: ${resolvedMovement.teamMoves.length} moves resolved`,
     });
     const movementPenalties = countTokenDelta(beforeMovement, next);
     if (movementPenalties > 0) {

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -21,6 +21,7 @@ import {
 } from './round.ts';
 
 type ExplicitMovementChoice = {
+  readonly kind: 'explicit';
   readonly teamId: TeamId;
   readonly intendedFacing: Facing;
   readonly gridSwapIndex?: 0 | 1;
@@ -29,6 +30,7 @@ type ExplicitMovementChoice = {
 };
 
 type EmergencyDrawMovementChoice = {
+  readonly kind: 'emergency-draw';
   readonly teamId: TeamId;
   readonly intendedFacing: Facing;
   readonly gridSwapIndex?: 0 | 1;
@@ -165,6 +167,10 @@ function resolveMovementChoices(
     }
   }
 
+  // Process every movement candidate in one team-number order so
+  // explicit submissions and emergency draws both stay deterministic
+  // regardless of submission order. This remains safe because
+  // movement later resolves each team's state independently.
   const orderedTeamIds = [...candidateIds].sort((a, b) => a - b);
   for (const teamId of orderedTeamIds) {
     const team = findTeam(next, teamId);
@@ -172,8 +178,6 @@ function resolveMovementChoices(
 
     const choice = choicesByTeam.get(teamId);
     if (team.cards.length === 0) {
-      // Simultaneous reveals need a deterministic engine order when
-      // multiple teams draw from the shared deck in the same step.
       const emergencyDraw = drawFromDeck(next.deck, 2);
       next = { ...next, deck: emergencyDraw.remaining };
       if (emergencyDraw.drawn.length === 0) {
@@ -191,9 +195,7 @@ function resolveMovementChoices(
       };
       next = updateTeam(next, replenishedTeam);
       const selectedDrawIndex =
-        choice !== undefined && 'emergencyDrawPick' in choice
-          ? (choice.emergencyDrawPick ?? 0)
-          : 0;
+        choice?.kind === 'emergency-draw' ? (choice.emergencyDrawPick ?? 0) : 0;
       const selectedCard =
         emergencyDraw.drawn[selectedDrawIndex] ?? emergencyDraw.drawn[0];
 
@@ -215,10 +217,15 @@ function resolveMovementChoices(
     }
 
     if (choice === undefined) continue;
+    if (choice.kind !== 'explicit') {
+      throw new RangeError(
+        `Team ${teamId} must use an explicit movement choice while cards remain in hand.`,
+      );
+    }
 
     resolvedMoves.push({
       teamId,
-      card: 'card' in choice ? choice.card : (team.cards[0] as Card),
+      card: choice.card,
       intendedFacing: choice.intendedFacing,
       ...(choice.gridSwapIndex !== undefined
         ? { gridSwapIndex: choice.gridSwapIndex }
@@ -299,6 +306,11 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   } else {
     const drawn = moveDraw.drawn[0] as Card;
     const attrCard = coerceToElementCard(drawn);
+    log.push({
+      round,
+      phase: 'movement',
+      message: `Movement attribute: ${attrCard.element}`,
+    });
     const movementInputState: RoundState = {
       ...next,
       deck: moveDraw.remaining,
@@ -318,7 +330,7 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
     log.push({
       round,
       phase: 'movement',
-      message: `Movement attribute: ${attrCard.element} (${resolvedMovement.teamMoves.length} moves submitted)`,
+      message: `Movement resolution: ${resolvedMovement.teamMoves.length} moves submitted`,
     });
     const movementPenalties = countTokenDelta(beforeMovement, next);
     if (movementPenalties > 0) {

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -178,6 +178,12 @@ function resolveMovementChoices(
 
     const choice = choicesByTeam.get(teamId);
     if (team.cards.length === 0) {
+      if (choice?.kind === 'explicit') {
+        throw new RangeError(
+          `Team ${teamId} cannot use an explicit movement choice with an empty hand.`,
+        );
+      }
+
       const emergencyDraw = drawFromDeck(next.deck, 2);
       next = { ...next, deck: emergencyDraw.remaining };
       if (emergencyDraw.drawn.length === 0) {

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -1,5 +1,7 @@
 import type { Card, Deck, ElementCard } from '../types/card.ts';
 import { isElementCard } from '../types/card.ts';
+import type { Facing, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS } from '../types/grid.ts';
 import type { LogEntry } from '../types/log.ts';
 import type { TeamId } from '../types/token.ts';
 import type { BattlePlay } from './battle.ts';
@@ -18,6 +20,30 @@ import {
   winner,
 } from './round.ts';
 
+type ExplicitMovementChoice = {
+  readonly teamId: TeamId;
+  readonly intendedFacing: Facing;
+  readonly gridSwapIndex?: 0 | 1;
+  /** Explicit card choice for a team that already has cards in hand. */
+  readonly card: Card;
+};
+
+type EmergencyDrawMovementChoice = {
+  readonly teamId: TeamId;
+  readonly intendedFacing: Facing;
+  readonly gridSwapIndex?: 0 | 1;
+  /**
+   * Optional emergency-draw pick for a hand-empty team. `0` chooses
+   * the first drawn card, `1` the second. When omitted or unavailable,
+   * the runner falls back to the first drawn card.
+   */
+  readonly emergencyDrawPick?: 0 | 1;
+};
+
+export type MovementChoice =
+  | ExplicitMovementChoice
+  | EmergencyDrawMovementChoice;
+
 /**
  * Inputs for a single round, one bundle per phase.
  *
@@ -31,7 +57,7 @@ export type RoundInputs = {
     readonly plays: readonly BattlePlay[];
   };
   readonly movement: {
-    readonly teamMoves: readonly TeamMove[];
+    readonly teamMoves: readonly MovementChoice[];
   };
   readonly revival: {
     readonly choices: ReadonlyMap<TeamId, RevivalAction>;
@@ -82,6 +108,125 @@ const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
 
 function coerceToElementCard(card: Card): ElementCard {
   return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
+}
+
+function allTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+function findTeam(state: RoundState, teamId: TeamId): TeamState | undefined {
+  return allTeams(state).find((team) => team.teamNumber === teamId);
+}
+
+function isTeamAlive(team: TeamState): boolean {
+  return team.players.some((player) => player.life > 0);
+}
+
+function updateTeam(state: RoundState, updated: TeamState): RoundState {
+  const { x, y } = updated.position;
+  return {
+    ...state,
+    grid: {
+      ...state.grid,
+      [x]: {
+        ...state.grid[x],
+        [y]: state.grid[x][y].map((team) =>
+          team.teamNumber === updated.teamNumber ? updated : team,
+        ),
+      },
+    },
+  } as RoundState;
+}
+
+function resolveMovementChoices(
+  state: RoundState,
+  movementChoices: readonly MovementChoice[],
+  round: number,
+  log: LogEntry[],
+): { state: RoundState; teamMoves: readonly TeamMove[] } {
+  let next = state;
+  const resolvedMoves: TeamMove[] = [];
+  const choicesByTeam = new Map<TeamId, MovementChoice>();
+  for (const choice of movementChoices) {
+    choicesByTeam.set(choice.teamId, choice);
+  }
+
+  const candidateIds = new Set<TeamId>(choicesByTeam.keys());
+  for (const team of allTeams(next)) {
+    if (!isTeamAlive(team)) continue;
+    if (team.cards.length === 0) {
+      candidateIds.add(team.teamNumber);
+    }
+  }
+
+  const orderedTeamIds = [...candidateIds].sort((a, b) => a - b);
+  for (const teamId of orderedTeamIds) {
+    const team = findTeam(next, teamId);
+    if (team === undefined || !isTeamAlive(team)) continue;
+
+    const choice = choicesByTeam.get(teamId);
+    if (team.cards.length === 0) {
+      // Simultaneous reveals need a deterministic engine order when
+      // multiple teams draw from the shared deck in the same step.
+      const emergencyDraw = drawFromDeck(next.deck, 2);
+      next = { ...next, deck: emergencyDraw.remaining };
+      if (emergencyDraw.drawn.length === 0) {
+        log.push({
+          round,
+          phase: 'movement',
+          message: `Team ${teamId} had no cards in hand and the deck was exhausted`,
+        });
+        continue;
+      }
+
+      const replenishedTeam: TeamState = {
+        ...team,
+        cards: [...team.cards, ...emergencyDraw.drawn],
+      };
+      next = updateTeam(next, replenishedTeam);
+      const selectedDrawIndex =
+        choice !== undefined && 'emergencyDrawPick' in choice
+          ? (choice.emergencyDrawPick ?? 0)
+          : 0;
+      const selectedCard =
+        emergencyDraw.drawn[selectedDrawIndex] ?? emergencyDraw.drawn[0];
+
+      resolvedMoves.push({
+        teamId,
+        card: selectedCard as Card,
+        intendedFacing: choice?.intendedFacing ?? team.facing,
+        ...(choice?.gridSwapIndex !== undefined
+          ? { gridSwapIndex: choice.gridSwapIndex }
+          : {}),
+      });
+
+      log.push({
+        round,
+        phase: 'movement',
+        message: `Team ${teamId} drew ${emergencyDraw.drawn.length} card(s) for the empty-hand movement fallback`,
+      });
+      continue;
+    }
+
+    if (choice === undefined) continue;
+
+    resolvedMoves.push({
+      teamId,
+      card: 'card' in choice ? choice.card : (team.cards[0] as Card),
+      intendedFacing: choice.intendedFacing,
+      ...(choice.gridSwapIndex !== undefined
+        ? { gridSwapIndex: choice.gridSwapIndex }
+        : {}),
+    });
+  }
+
+  return { state: next, teamMoves: resolvedMoves };
 }
 
 /**
@@ -154,16 +299,26 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   } else {
     const drawn = moveDraw.drawn[0] as Card;
     const attrCard = coerceToElementCard(drawn);
-    const beforeMovement: RoundState = { ...next, deck: moveDraw.remaining };
+    const movementInputState: RoundState = {
+      ...next,
+      deck: moveDraw.remaining,
+    };
+    const resolvedMovement = resolveMovementChoices(
+      movementInputState,
+      inputs.movement.teamMoves,
+      round,
+      log,
+    );
+    const beforeMovement = resolvedMovement.state;
     next = advanceMovement(
       beforeMovement,
       attrCard.element,
-      inputs.movement.teamMoves,
+      resolvedMovement.teamMoves,
     );
     log.push({
       round,
       phase: 'movement',
-      message: `Movement attribute: ${attrCard.element} (${inputs.movement.teamMoves.length} moves submitted)`,
+      message: `Movement attribute: ${attrCard.element} (${resolvedMovement.teamMoves.length} moves submitted)`,
     });
     const movementPenalties = countTokenDelta(beforeMovement, next);
     if (movementPenalties > 0) {


### PR DESCRIPTION
## Summary
- add the movement-phase empty-hand fallback draw inside `runRound` before `advanceMovement`
- allow callers to pick which emergency-drawn card becomes the movement play while keeping a deterministic first-card default
- add coverage for 2-card fallback draw, 1-card fallback draw, empty-deck no-throw behavior, and grid-card swap / graveyard cooperation

Closes #119

## Follow-up
- none

## Notes
- simultaneous empty-hand fallback draws consume the shared deck in ascending team-number order so engine behavior stays deterministic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Emergency-draw fallback: teams with no hand can draw up to two cards from the shared deck during movement, consume one for movement, and keep the other in hand.
  * Movement input now supports explicit choices or emergency-draw submissions, improving movement flexibility and clarity.

* **Bug Fixes**
  * Deterministic resolution and robust handling when the deck is low or exhausted during movement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
