### PR TITLE
feat(core): add bot strategy interface and random bot

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,8 @@ export * from './logic/resolve.ts';
 export * from './logic/round.ts';
 export * from './logic/runner.ts';
 export * from './logic/setup.ts';
+export * from './strategy/random.ts';
+export * from './strategy/strategy.ts';
 export * from './types/card.ts';
 export * from './types/grid.ts';
 export * from './types/log.ts';

--- a/packages/core/src/strategy/random.test.ts
+++ b/packages/core/src/strategy/random.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONFIG } from '../config.ts';
+import type { BattlePlay } from '../logic/battle.ts';
+import { resolveBattlePhase } from '../logic/battle.ts';
+import type { RevivalAction, RoundState } from '../logic/round.ts';
+import {
+  createEmptyDroppedTokens,
+  createEmptyGrid,
+  isGameOver,
+} from '../logic/round.ts';
+import type { InputProvider, MovementChoice } from '../logic/runner.ts';
+import { runUntilGameOver } from '../logic/runner.ts';
+import { setupGame } from '../logic/setup.ts';
+import type { Card, ElementCard, JokerCard } from '../types/card.ts';
+import type { GridCoord, TeamState } from '../types/grid.ts';
+import { createLifeToken, type NumberToken } from '../types/token.ts';
+import { randomStrategy } from './random.ts';
+
+const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+const wood4: ElementCard = { kind: 'element', element: 'wood', value: 4 };
+const joker: JokerCard = { kind: 'joker' };
+const fireWater: GridCoord = { x: 'fire', y: 'water' };
+
+function makeTeam(opts: {
+  id: NumberToken;
+  position: GridCoord;
+  life?: number;
+  members?: 1 | 2;
+  cards?: readonly Card[];
+  gridCards?: readonly [Card, Card];
+}): TeamState {
+  const life = opts.life ?? 4;
+  const members = opts.members ?? 1;
+  const players =
+    members === 1
+      ? [{ life: createLifeToken(life) }]
+      : [{ life: createLifeToken(life) }, { life: createLifeToken(life) }];
+  return {
+    teamNumber: opts.id,
+    position: opts.position,
+    facing: 'north',
+    cards: opts.cards ?? [],
+    players,
+    ...(opts.gridCards ? { gridCards: opts.gridCards } : {}),
+  };
+}
+
+function stateWith(
+  teams: readonly TeamState[],
+  deck: readonly Card[] = [],
+): RoundState {
+  let grid = createEmptyGrid();
+  for (const team of teams) {
+    const { x, y } = team.position;
+    grid = {
+      ...grid,
+      [x]: { ...grid[x], [y]: [...grid[x][y], team] },
+    } as typeof grid;
+  }
+  return {
+    phase: 'battle',
+    round: 1,
+    grid,
+    forbiddenCells: [],
+    deck: [...deck],
+    graveyard: [],
+  };
+}
+
+function allTeams(state: RoundState): TeamState[] {
+  return Object.values(state.grid).flatMap((row) =>
+    Object.values(row).flatMap((cell) => [...cell]),
+  );
+}
+
+function makeBotProvider(
+  strategies: ReadonlyMap<NumberToken, ReturnType<typeof randomStrategy>>,
+): InputProvider {
+  return (state) => {
+    const plays: BattlePlay[] = [];
+    for (const team of allTeams(state)) {
+      const strategy = strategies.get(team.teamNumber);
+      if (strategy === undefined) continue;
+      const battle = strategy.chooseBattlePlay(state, team.teamNumber);
+      plays.push({ teamId: team.teamNumber, card: battle.card });
+    }
+
+    const afterBattle = resolveBattlePhase(state, plays).state;
+    const teamMoves: MovementChoice[] = [];
+    const revivalChoices = new Map<NumberToken, RevivalAction>();
+
+    for (const team of allTeams(afterBattle)) {
+      const strategy = strategies.get(team.teamNumber);
+      if (strategy === undefined) continue;
+
+      const movement = strategy.chooseTeamMove(afterBattle, team.teamNumber);
+      if (movement !== null) {
+        teamMoves.push({ teamId: team.teamNumber, ...movement });
+      }
+
+      const revival = strategy.chooseRevivalAction(
+        afterBattle,
+        team.teamNumber,
+      );
+      if (revival !== null) {
+        revivalChoices.set(team.teamNumber, revival);
+      }
+    }
+
+    return {
+      battle: { plays },
+      movement: { teamMoves },
+      revival: { choices: revivalChoices },
+    };
+  };
+}
+
+describe('randomStrategy', () => {
+  it('is deterministic with the same seed and call order', () => {
+    const team = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      cards: [fire5, water3, wood1],
+      gridCards: [fire5, water3],
+    });
+    const state = stateWith([team]);
+    const left = randomStrategy(42);
+    const right = randomStrategy(42);
+
+    expect(left.chooseBattlePlay(state, 1 as NumberToken)).toEqual(
+      right.chooseBattlePlay(state, 1 as NumberToken),
+    );
+    expect(left.chooseTeamMove(state, 1 as NumberToken)).toEqual(
+      right.chooseTeamMove(state, 1 as NumberToken),
+    );
+    expect(left.chooseRevivalAction(state, 1 as NumberToken)).toEqual(
+      right.chooseRevivalAction(state, 1 as NumberToken),
+    );
+  });
+
+  it('chooses only cards that are actually in the team hand for battle and explicit movement', () => {
+    const team = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      cards: [fire5, water3, wood1, joker],
+      gridCards: [fire5, water3],
+    });
+    const state = stateWith([team]);
+
+    for (let seed = 1; seed <= 32; seed += 1) {
+      const strategy = randomStrategy(seed);
+      const battle = strategy.chooseBattlePlay(state, 1 as NumberToken);
+      if (battle.card !== null) {
+        expect(team.cards).toContainEqual(battle.card);
+      }
+
+      const movement = strategy.chooseTeamMove(state, 1 as NumberToken);
+      expect(movement).not.toBeNull();
+      if (movement?.kind === 'explicit') {
+        expect(team.cards).toContainEqual(movement.card);
+      }
+    }
+  });
+
+  it('uses the emergency-draw movement path when the team hand is empty', () => {
+    const team = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      cards: [],
+      gridCards: [fire5, water3],
+    });
+    const state = stateWith([team], [wood1, wood4]);
+    const strategy = randomStrategy(7);
+
+    expect(strategy.chooseBattlePlay(state, 1 as NumberToken)).toEqual({
+      card: null,
+    });
+    expect(strategy.chooseTeamMove(state, 1 as NumberToken)).toMatchObject({
+      kind: 'emergency-draw',
+    });
+  });
+
+  it('handles dead teams and missing team ids without throwing', () => {
+    const deadTeam = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 0,
+      cards: [fire5],
+      gridCards: [fire5, water3],
+    });
+    const state = stateWith([deadTeam]);
+    const strategy = randomStrategy(9);
+
+    expect(strategy.chooseBattlePlay(state, 1 as NumberToken)).toEqual({
+      card: null,
+    });
+    expect(strategy.chooseTeamMove(state, 1 as NumberToken)).toBeNull();
+    expect(strategy.chooseRevivalAction(state, 1 as NumberToken)).toBeNull();
+    expect(strategy.chooseBattlePlay(state, 2 as NumberToken)).toEqual({
+      card: null,
+    });
+    expect(strategy.chooseTeamMove(state, 2 as NumberToken)).toBeNull();
+    expect(strategy.chooseRevivalAction(state, 2 as NumberToken)).toBeNull();
+  });
+
+  it('drives a deterministic finished bot-vs-bot game within maxRounds', () => {
+    const initial = setupGame(
+      { playerCount: 4, seed: 20260521 },
+      DEFAULT_CONFIG,
+    );
+    const teamIds = allTeams(initial).map((team) => team.teamNumber);
+    const strategies = new Map(
+      teamIds.map(
+        (teamId) => [teamId, randomStrategy(10_000 + teamId)] as const,
+      ),
+    );
+    const provider = makeBotProvider(strategies);
+    const first = runUntilGameOver(initial, provider, 100);
+    const secondInitial = setupGame(
+      { playerCount: 4, seed: 20260521 },
+      DEFAULT_CONFIG,
+    );
+    const secondStrategies = new Map(
+      allTeams(secondInitial).map(
+        (team) =>
+          [team.teamNumber, randomStrategy(10_000 + team.teamNumber)] as const,
+      ),
+    );
+    const secondProvider = makeBotProvider(secondStrategies);
+    const second = runUntilGameOver(secondInitial, secondProvider, 100);
+
+    expect(isGameOver(first.state)).toBe(true);
+    expect(first.rounds).toBeLessThanOrEqual(100);
+    expect(first.winner).toBe(second.winner);
+    expect(first.rounds).toBe(second.rounds);
+    expect(first.state).toEqual(second.state);
+  });
+
+  it('returns null revival action when no legal revival option exists', () => {
+    const team = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      cards: [fire5],
+      gridCards: [fire5, water3],
+    });
+    const state = {
+      ...stateWith([team]),
+      droppedLifeTokens: createEmptyDroppedTokens(),
+    };
+    const strategy = randomStrategy(4);
+
+    expect(strategy.chooseRevivalAction(state, 1 as NumberToken)).toBeNull();
+  });
+});

--- a/packages/core/src/strategy/random.test.ts
+++ b/packages/core/src/strategy/random.test.ts
@@ -12,7 +12,7 @@ import type { InputProvider, MovementChoice } from '../logic/runner.ts';
 import { runUntilGameOver } from '../logic/runner.ts';
 import { setupGame } from '../logic/setup.ts';
 import type { Card, ElementCard, JokerCard } from '../types/card.ts';
-import type { GridCoord, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS, type GridCoord, type TeamState } from '../types/grid.ts';
 import { createLifeToken, type NumberToken } from '../types/token.ts';
 import { randomStrategy } from './random.ts';
 
@@ -70,9 +70,13 @@ function stateWith(
 }
 
 function allTeams(state: RoundState): TeamState[] {
-  return Object.values(state.grid).flatMap((row) =>
-    Object.values(row).flatMap((cell) => [...cell]),
-  );
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
+    }
+  }
+  return teams;
 }
 
 function makeBotProvider(

--- a/packages/core/src/strategy/random.ts
+++ b/packages/core/src/strategy/random.ts
@@ -1,0 +1,103 @@
+import { createRng } from '../logic/deck.ts';
+import type { RevivalAction, RoundState } from '../logic/round.ts';
+import type { Facing } from '../types/grid.ts';
+import type { TeamId } from '../types/token.ts';
+import {
+  findTeam,
+  isTeamAlive,
+  type StrategyMovementChoice,
+  type TeamStrategy,
+} from './strategy.ts';
+
+const FACINGS: readonly Facing[] = ['north', 'east', 'south', 'west'];
+const BATTLE_FORFEIT_PROBABILITY = 0.1;
+
+function pickOne<T>(items: readonly T[], rng: () => number): T {
+  const index = Math.floor(rng() * items.length);
+  return items[index] as T;
+}
+
+function randomFacing(rng: () => number): Facing {
+  return pickOne(FACINGS, rng);
+}
+
+function randomGridSwapIndex(rng: () => number): 0 | 1 {
+  return rng() < 0.5 ? 0 : 1;
+}
+
+function randomMovementChoice(
+  state: RoundState,
+  teamId: TeamId,
+  rng: () => number,
+): StrategyMovementChoice | null {
+  const team = findTeam(state, teamId);
+  if (team === undefined || !isTeamAlive(team)) return null;
+
+  if (team.cards.length === 0) {
+    return {
+      kind: 'emergency-draw',
+      intendedFacing: randomFacing(rng),
+      gridSwapIndex: randomGridSwapIndex(rng),
+      emergencyDrawPick: randomGridSwapIndex(rng),
+    };
+  }
+
+  return {
+    kind: 'explicit',
+    card: pickOne(team.cards, rng),
+    intendedFacing: randomFacing(rng),
+    gridSwapIndex: randomGridSwapIndex(rng),
+  };
+}
+
+function revivalOptions(state: RoundState, teamId: TeamId): RevivalAction[] {
+  const team = findTeam(state, teamId);
+  if (team === undefined || !isTeamAlive(team)) return [];
+
+  const dropped =
+    state.droppedLifeTokens?.[team.position.x]?.[team.position.y] ?? 0;
+  if (dropped <= 0) return [];
+  const cohabitants = state.grid[team.position.x][team.position.y].filter(
+    (other) => other.teamNumber !== team.teamNumber,
+  );
+  if (cohabitants.length > 0) return [];
+
+  const options: RevivalAction[] = [{ type: 'charge-cards' }];
+  if (team.players.some((player) => player.life === 0)) {
+    options.push({ type: 'revive-member' });
+  }
+  if (team.players.some((player) => player.life > 0 && player.life < 4)) {
+    options.push({ type: 'charge-life' });
+  }
+  return options;
+}
+
+/**
+ * Creates a strategy that picks reproducible pseudo-random legal choices.
+ */
+export function randomStrategy(seed: number): TeamStrategy {
+  const rng = createRng(seed);
+
+  return {
+    chooseBattlePlay(state, teamId) {
+      const team = findTeam(state, teamId);
+      if (team === undefined || !isTeamAlive(team) || team.cards.length === 0) {
+        return { card: null };
+      }
+      if (rng() < BATTLE_FORFEIT_PROBABILITY) {
+        return { card: null };
+      }
+      return { card: pickOne(team.cards, rng) };
+    },
+    chooseTeamMove(state, teamId) {
+      return randomMovementChoice(state, teamId, rng);
+    },
+    chooseRevivalAction(state, teamId) {
+      const options = revivalOptions(state, teamId);
+      if (options.length === 0) return null;
+
+      const maybeSkip = [...options, null] as const;
+      return pickOne(maybeSkip, rng);
+    },
+  };
+}

--- a/packages/core/src/strategy/strategy.ts
+++ b/packages/core/src/strategy/strategy.ts
@@ -1,7 +1,7 @@
 import type { BattlePlay } from '../logic/battle.ts';
 import type { RevivalAction, RoundState } from '../logic/round.ts';
 import type { MovementChoice } from '../logic/runner.ts';
-import type { TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS, type TeamState } from '../types/grid.ts';
 import type { TeamId } from '../types/token.ts';
 
 type ExplicitStrategyMovementChoice = Omit<
@@ -38,9 +38,9 @@ export type TeamStrategy = {
 
 function allTeams(state: RoundState): TeamState[] {
   const teams: TeamState[] = [];
-  for (const row of Object.values(state.grid)) {
-    for (const cell of Object.values(row)) {
-      teams.push(...cell);
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
     }
   }
   return teams;

--- a/packages/core/src/strategy/strategy.ts
+++ b/packages/core/src/strategy/strategy.ts
@@ -1,0 +1,60 @@
+import type { BattlePlay } from '../logic/battle.ts';
+import type { RevivalAction, RoundState } from '../logic/round.ts';
+import type { MovementChoice } from '../logic/runner.ts';
+import type { TeamState } from '../types/grid.ts';
+import type { TeamId } from '../types/token.ts';
+
+type ExplicitStrategyMovementChoice = Omit<
+  Extract<MovementChoice, { readonly kind: 'explicit' }>,
+  'teamId'
+>;
+
+type EmergencyDrawStrategyMovementChoice = Omit<
+  Extract<MovementChoice, { readonly kind: 'emergency-draw' }>,
+  'teamId'
+>;
+
+export type StrategyBattleChoice = Pick<BattlePlay, 'card'>;
+
+export type StrategyMovementChoice =
+  | ExplicitStrategyMovementChoice
+  | EmergencyDrawStrategyMovementChoice;
+
+/** Strategy callbacks for one team. */
+export type TeamStrategy = {
+  readonly chooseBattlePlay: (
+    state: RoundState,
+    teamId: TeamId,
+  ) => StrategyBattleChoice;
+  readonly chooseTeamMove: (
+    state: RoundState,
+    teamId: TeamId,
+  ) => StrategyMovementChoice | null;
+  readonly chooseRevivalAction: (
+    state: RoundState,
+    teamId: TeamId,
+  ) => RevivalAction | null;
+};
+
+function allTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const row of Object.values(state.grid)) {
+    for (const cell of Object.values(row)) {
+      teams.push(...cell);
+    }
+  }
+  return teams;
+}
+
+/** Returns the current team snapshot for a team id, if still on the board. */
+export function findTeam(
+  state: RoundState,
+  teamId: TeamId,
+): TeamState | undefined {
+  return allTeams(state).find((team) => team.teamNumber === teamId);
+}
+
+/** Returns true when the team still has at least one living player. */
+export function isTeamAlive(team: TeamState): boolean {
+  return team.players.some((player) => player.life > 0);
+}


### PR DESCRIPTION
Closes #123

## Summary
- add a core strategy interface for battle, movement, and revival choices
- add a seeded random strategy reference implementation with legal-option guards
- add deterministic strategy tests, including a bot-vs-bot smoke test

## Verification
- pnpm run lint:fix
- pnpm run test
- pnpm -r typecheck
- pnpm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic random strategy implementation enabling bot players with configurable decision-making for battles, movement, and revival actions
  * Exposed strategy layer in public API with types and utility functions to support custom team strategy implementations

* **Tests**
  * Added comprehensive test suite validating strategy determinism, correctness of game selections, and bot-vs-bot gameplay scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->