### PR TITLE
feat(core): add mixed-control session manager

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export * from './logic/resolve.ts';
 export * from './logic/round.ts';
 export * from './logic/runner.ts';
 export * from './logic/setup.ts';
+export * from './session/session.ts';
 export * from './strategy/random.ts';
 export * from './strategy/strategy.ts';
 export * from './types/card.ts';

--- a/packages/core/src/logic/phase-helpers.ts
+++ b/packages/core/src/logic/phase-helpers.ts
@@ -26,6 +26,10 @@ export type MovementChoice =
   | EmergencyDrawMovementChoice;
 
 type MovementEventLogger = (message: string) => void;
+type InvalidExplicitChoicePolicy = 'skip' | 'throw';
+type ResolveMovementOptions = {
+  readonly invalidExplicitChoice?: InvalidExplicitChoicePolicy;
+};
 
 /**
  * Phase-draw Joker fallback: forbidden-cell coordinates and the
@@ -94,11 +98,18 @@ export function coerceToElementCard(card: Card): ElementCard {
   return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
 }
 
-function hasMatchingCard(hand: readonly Card[], target: Card): boolean {
+function describeCard(card: Card): string {
+  return card.kind === 'joker' ? 'Joker' : `${card.element} ${card.value}`;
+}
+
+function findMatchingCard(
+  hand: readonly Card[],
+  target: Card,
+): Card | undefined {
   if (target.kind === 'joker') {
-    return hand.some((card) => card.kind === 'joker');
+    return hand.find((card) => card.kind === 'joker');
   }
-  return hand.some(
+  return hand.find(
     (card) =>
       card.kind === 'element' &&
       card.element === target.element &&
@@ -110,6 +121,7 @@ export function resolveMovementChoices(
   state: RoundState,
   movementChoices: readonly MovementChoice[],
   onEvent?: MovementEventLogger,
+  options: ResolveMovementOptions = {},
 ): { state: RoundState; teamMoves: readonly TeamMove[] } {
   let next = state;
   const resolvedMoves: TeamMove[] = [];
@@ -197,13 +209,19 @@ export function resolveMovementChoices(
       continue;
     }
 
-    if (!hasMatchingCard(team.cards, choice.card)) {
-      continue;
+    const matchedCard = findMatchingCard(team.cards, choice.card);
+    if (matchedCard === undefined) {
+      if ((options.invalidExplicitChoice ?? 'throw') === 'skip') {
+        continue;
+      }
+      throw new RangeError(
+        `Team ${teamId} cannot play ${describeCard(choice.card)} for movement: not in hand.`,
+      );
     }
 
     resolvedMoves.push({
       teamId,
-      card: choice.card,
+      card: matchedCard,
       intendedFacing: choice.intendedFacing,
       ...(choice.gridSwapIndex !== undefined
         ? { gridSwapIndex: choice.gridSwapIndex }

--- a/packages/core/src/logic/phase-helpers.ts
+++ b/packages/core/src/logic/phase-helpers.ts
@@ -1,0 +1,197 @@
+import type { Card, Deck, ElementCard } from '../types/card.ts';
+import { isElementCard } from '../types/card.ts';
+import type { Facing, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS } from '../types/grid.ts';
+import type { TeamId } from '../types/token.ts';
+import type { RoundState, TeamMove } from './round.ts';
+
+type ExplicitMovementChoice = {
+  readonly kind: 'explicit';
+  readonly teamId: TeamId;
+  readonly intendedFacing: Facing;
+  readonly gridSwapIndex?: 0 | 1;
+  readonly card: Card;
+};
+
+type EmergencyDrawMovementChoice = {
+  readonly kind: 'emergency-draw';
+  readonly teamId: TeamId;
+  readonly intendedFacing: Facing;
+  readonly gridSwapIndex?: 0 | 1;
+  readonly emergencyDrawPick?: 0 | 1;
+};
+
+export type MovementChoice =
+  | ExplicitMovementChoice
+  | EmergencyDrawMovementChoice;
+
+type MovementEventLogger = (message: string) => void;
+
+/**
+ * Forbidden-phase Joker fallback: when the GM "draws" a Joker for
+ * the forbidden cell coordinate, the rules call for an "attribute
+ * card" but don't define joker semantics for the forbidden marker.
+ * v1 uses 'fire' as a deterministic fallback element coordinate.
+ */
+const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
+  kind: 'element',
+  element: 'fire',
+  value: 1,
+};
+
+function allTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+function findTeam(state: RoundState, teamId: TeamId): TeamState | undefined {
+  return allTeams(state).find((team) => team.teamNumber === teamId);
+}
+
+function isTeamAlive(team: TeamState): boolean {
+  return team.players.some((player) => player.life > 0);
+}
+
+function updateTeam(state: RoundState, updated: TeamState): RoundState {
+  const { x, y } = updated.position;
+  return {
+    ...state,
+    grid: {
+      ...state.grid,
+      [x]: {
+        ...state.grid[x],
+        [y]: state.grid[x][y].map((team) =>
+          team.teamNumber === updated.teamNumber ? updated : team,
+        ),
+      },
+    },
+  } as RoundState;
+}
+
+/**
+ * Draws up to `count` cards from the head of the deck.
+ * Returns the drawn cards (in original order) and the remaining deck.
+ * Caller is responsible for handling fewer-than-`count` draws.
+ */
+export function drawFromDeck(
+  deck: Deck | undefined,
+  count: number,
+): { drawn: readonly Card[]; remaining: Deck } {
+  const source = deck ?? [];
+  const drawn = source.slice(0, count);
+  const remaining = source.slice(count);
+  return { drawn, remaining };
+}
+
+export function coerceToElementCard(card: Card): ElementCard {
+  return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
+}
+
+export function resolveMovementChoices(
+  state: RoundState,
+  movementChoices: readonly MovementChoice[],
+  onEvent?: MovementEventLogger,
+): { state: RoundState; teamMoves: readonly TeamMove[] } {
+  let next = state;
+  const resolvedMoves: TeamMove[] = [];
+  const choicesByTeam = new Map<TeamId, MovementChoice>();
+  for (const choice of movementChoices) {
+    choicesByTeam.set(choice.teamId, choice);
+  }
+
+  const candidateIds = new Set<TeamId>(choicesByTeam.keys());
+  for (const team of allTeams(next)) {
+    if (!isTeamAlive(team)) continue;
+    if (team.cards.length === 0) {
+      candidateIds.add(team.teamNumber);
+    }
+  }
+
+  const orderedTeamIds = [...candidateIds].sort((a, b) => a - b);
+  for (const teamId of orderedTeamIds) {
+    const team = findTeam(next, teamId);
+    if (team === undefined || !isTeamAlive(team)) continue;
+
+    const choice = choicesByTeam.get(teamId);
+    if (team.cards.length === 0) {
+      if (choice?.kind === 'explicit') {
+        throw new RangeError(
+          `Team ${teamId} cannot use an explicit movement choice with an empty hand.`,
+        );
+      }
+
+      const emergencyDraw = drawFromDeck(next.deck, 2);
+      next = { ...next, deck: emergencyDraw.remaining };
+      const [firstDrawnCard, secondDrawnCard] = emergencyDraw.drawn;
+      if (firstDrawnCard === undefined) {
+        onEvent?.(
+          `Team ${teamId} had no cards in hand and the deck was exhausted`,
+        );
+        continue;
+      }
+
+      const replenishedTeam: TeamState = {
+        ...team,
+        cards: [...team.cards, ...emergencyDraw.drawn],
+      };
+      next = updateTeam(next, replenishedTeam);
+      onEvent?.(
+        `Team ${teamId} drew ${emergencyDraw.drawn.length} card(s) for the empty-hand movement fallback`,
+      );
+      if (choice?.kind !== 'emergency-draw') {
+        onEvent?.(
+          `Team ${teamId} had no movement submission after the empty-hand movement fallback draw`,
+        );
+        continue;
+      }
+
+      const selectedDrawIndex = choice.emergencyDrawPick ?? 0;
+      const selectedCard =
+        selectedDrawIndex === 1
+          ? (secondDrawnCard ?? firstDrawnCard)
+          : firstDrawnCard;
+
+      resolvedMoves.push({
+        teamId,
+        card: selectedCard,
+        intendedFacing: choice.intendedFacing,
+        ...(choice.gridSwapIndex !== undefined
+          ? { gridSwapIndex: choice.gridSwapIndex }
+          : {}),
+      });
+      continue;
+    }
+
+    if (choice === undefined) continue;
+    if (choice.kind === 'emergency-draw') {
+      const [firstHandCard] = team.cards;
+      if (firstHandCard === undefined) continue;
+
+      resolvedMoves.push({
+        teamId,
+        card: firstHandCard,
+        intendedFacing: choice.intendedFacing,
+        ...(choice.gridSwapIndex !== undefined
+          ? { gridSwapIndex: choice.gridSwapIndex }
+          : {}),
+      });
+      continue;
+    }
+
+    resolvedMoves.push({
+      teamId,
+      card: choice.card,
+      intendedFacing: choice.intendedFacing,
+      ...(choice.gridSwapIndex !== undefined
+        ? { gridSwapIndex: choice.gridSwapIndex }
+        : {}),
+    });
+  }
+
+  return { state: next, teamMoves: resolvedMoves };
+}

--- a/packages/core/src/logic/phase-helpers.ts
+++ b/packages/core/src/logic/phase-helpers.ts
@@ -28,10 +28,9 @@ export type MovementChoice =
 type MovementEventLogger = (message: string) => void;
 
 /**
- * Forbidden-phase Joker fallback: when the GM "draws" a Joker for
- * the forbidden cell coordinate, the rules call for an "attribute
- * card" but don't define joker semantics for the forbidden marker.
- * v1 uses 'fire' as a deterministic fallback element coordinate.
+ * Phase-draw Joker fallback: forbidden-cell coordinates and the
+ * movement attribute both require element cards, so v1 coerces any
+ * joker draw to a deterministic fire attribute.
  */
 const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
   kind: 'element',
@@ -73,7 +72,7 @@ export function updateTeam(state: RoundState, updated: TeamState): RoundState {
         ),
       },
     },
-  } as RoundState;
+  };
 }
 
 /**
@@ -93,6 +92,18 @@ export function drawFromDeck(
 
 export function coerceToElementCard(card: Card): ElementCard {
   return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
+}
+
+function hasMatchingCard(hand: readonly Card[], target: Card): boolean {
+  if (target.kind === 'joker') {
+    return hand.some((card) => card.kind === 'joker');
+  }
+  return hand.some(
+    (card) =>
+      card.kind === 'element' &&
+      card.element === target.element &&
+      card.value === target.value,
+  );
 }
 
 export function resolveMovementChoices(
@@ -183,6 +194,10 @@ export function resolveMovementChoices(
           ? { gridSwapIndex: choice.gridSwapIndex }
           : {}),
       });
+      continue;
+    }
+
+    if (!hasMatchingCard(team.cards, choice.card)) {
       continue;
     }
 

--- a/packages/core/src/logic/phase-helpers.ts
+++ b/packages/core/src/logic/phase-helpers.ts
@@ -29,6 +29,7 @@ type MovementEventLogger = (message: string) => void;
 type InvalidExplicitChoicePolicy = 'skip' | 'throw';
 type ResolveMovementOptions = {
   readonly invalidExplicitChoice?: InvalidExplicitChoicePolicy;
+  readonly skipInvalidExplicitChoiceTeamIds?: ReadonlySet<TeamId>;
 };
 
 /**
@@ -36,7 +37,7 @@ type ResolveMovementOptions = {
  * movement attribute both require element cards, so v1 coerces any
  * joker draw to a deterministic fire attribute.
  */
-const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
+const JOKER_ELEMENT_FALLBACK: ElementCard = {
   kind: 'element',
   element: 'fire',
   value: 1,
@@ -52,6 +53,7 @@ export function allTeams(state: RoundState): TeamState[] {
   return teams;
 }
 
+/** Returns the current team snapshot for a team id, if still on the board. */
 export function findTeam(
   state: RoundState,
   teamId: TeamId,
@@ -59,6 +61,7 @@ export function findTeam(
   return allTeams(state).find((team) => team.teamNumber === teamId);
 }
 
+/** Returns whether a team still has at least one living player. */
 export function isTeamAlive(team: TeamState): boolean {
   return team.players.some((player) => player.life > 0);
 }
@@ -95,7 +98,7 @@ export function drawFromDeck(
 }
 
 export function coerceToElementCard(card: Card): ElementCard {
-  return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
+  return isElementCard(card) ? card : JOKER_ELEMENT_FALLBACK;
 }
 
 function describeCard(card: Card): string {
@@ -211,7 +214,11 @@ export function resolveMovementChoices(
 
     const matchedCard = findMatchingCard(team.cards, choice.card);
     if (matchedCard === undefined) {
-      if ((options.invalidExplicitChoice ?? 'throw') === 'skip') {
+      const invalidExplicitChoicePolicy =
+        options.skipInvalidExplicitChoiceTeamIds?.has(teamId)
+          ? 'skip'
+          : (options.invalidExplicitChoice ?? 'throw');
+      if (invalidExplicitChoicePolicy === 'skip') {
         continue;
       }
       throw new RangeError(

--- a/packages/core/src/logic/phase-helpers.ts
+++ b/packages/core/src/logic/phase-helpers.ts
@@ -39,7 +39,7 @@ const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
   value: 1,
 };
 
-function allTeams(state: RoundState): TeamState[] {
+export function allTeams(state: RoundState): TeamState[] {
   const teams: TeamState[] = [];
   for (const x of ELEMENT_AXIS) {
     for (const y of ELEMENT_AXIS) {
@@ -49,15 +49,18 @@ function allTeams(state: RoundState): TeamState[] {
   return teams;
 }
 
-function findTeam(state: RoundState, teamId: TeamId): TeamState | undefined {
+export function findTeam(
+  state: RoundState,
+  teamId: TeamId,
+): TeamState | undefined {
   return allTeams(state).find((team) => team.teamNumber === teamId);
 }
 
-function isTeamAlive(team: TeamState): boolean {
+export function isTeamAlive(team: TeamState): boolean {
   return team.players.some((player) => player.life > 0);
 }
 
-function updateTeam(state: RoundState, updated: TeamState): RoundState {
+export function updateTeam(state: RoundState, updated: TeamState): RoundState {
   const { x, y } = updated.position;
   return {
     ...state,

--- a/packages/core/src/logic/runner.test.ts
+++ b/packages/core/src/logic/runner.test.ts
@@ -594,6 +594,42 @@ describe('runRound', () => {
     );
   });
 
+  it('rejects explicit movement choices that reference cards not in hand', () => {
+    const teamA = makeTeam({
+      id: 1 as NumberToken,
+      position: fireWater,
+      life: 4,
+      gridCards: [wood4, wood1],
+      cards: [water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as NumberToken,
+      position: waterWater,
+      life: 4,
+      gridCards: [fire5, water3],
+      cards: [fire5],
+    });
+    const s = stateWith([teamA, teamB], [wood1, wood1, fire5]);
+
+    expect(() =>
+      runRound(
+        s,
+        makeInputs({
+          teamMoves: [
+            {
+              kind: 'explicit',
+              teamId: 1 as NumberToken,
+              card: fire5,
+              intendedFacing: 'east',
+            },
+          ],
+        }),
+      ),
+    ).toThrowError(
+      new RangeError('Team 1 cannot play fire 5 for movement: not in hand.'),
+    );
+  });
+
   it('treats a drawn Joker as the fire-element fallback for forbidden coord', () => {
     const teamA = makeTeam({
       id: 1 as NumberToken,

--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -1,17 +1,15 @@
-import type { Card, Deck, ElementCard } from '../types/card.ts';
-import { isElementCard } from '../types/card.ts';
-import type { Facing, TeamState } from '../types/grid.ts';
-import { ELEMENT_AXIS } from '../types/grid.ts';
+import type { Card } from '../types/card.ts';
 import type { LogEntry } from '../types/log.ts';
 import type { TeamId } from '../types/token.ts';
 import type { BattlePlay } from './battle.ts';
 import { resolveBattlePhase } from './battle.ts';
-import type {
-  BattleResult,
-  RevivalAction,
-  RoundState,
-  TeamMove,
-} from './round.ts';
+import {
+  coerceToElementCard,
+  drawFromDeck,
+  type MovementChoice,
+  resolveMovementChoices,
+} from './phase-helpers.ts';
+import type { BattleResult, RevivalAction, RoundState } from './round.ts';
 import {
   advanceForbidden,
   advanceMovement,
@@ -20,33 +18,7 @@ import {
   winner,
 } from './round.ts';
 
-type ExplicitMovementChoice = {
-  readonly kind: 'explicit';
-  readonly teamId: TeamId;
-  readonly intendedFacing: Facing;
-  readonly gridSwapIndex?: 0 | 1;
-  /** Explicit card choice for a team that already has cards in hand. */
-  readonly card: Card;
-};
-
-type EmergencyDrawMovementChoice = {
-  readonly kind: 'emergency-draw';
-  readonly teamId: TeamId;
-  readonly intendedFacing: Facing;
-  readonly gridSwapIndex?: 0 | 1;
-  /**
-   * Optional emergency-draw pick for a hand-empty team. `0` chooses
-   * the first drawn card, `1` the second. When omitted or unavailable,
-   * the runner falls back to the first drawn card. If battle-side
-   * card flow leaves cards in hand after input collection, the runner
-   * instead consumes the first remaining hand card heuristically.
-   */
-  readonly emergencyDrawPick?: 0 | 1;
-};
-
-export type MovementChoice =
-  | ExplicitMovementChoice
-  | EmergencyDrawMovementChoice;
+export type { MovementChoice } from './phase-helpers.ts';
 
 /**
  * Inputs for a single round, one bundle per phase.
@@ -81,186 +53,6 @@ function battleLogMessage(result: BattleResult): string {
   }
   const loser = result.winner === result.teamA ? result.teamB : result.teamA;
   return `Team ${result.winner} hit Team ${loser} for ${result.damage} damage (${result.encounterType})`;
-}
-
-/**
- * Draws up to `count` cards from the head of the deck.
- * Returns the drawn cards (in original order) and the remaining deck.
- * Caller is responsible for handling fewer-than-`count` draws.
- */
-function drawFromDeck(
-  deck: Deck | undefined,
-  count: number,
-): { drawn: readonly Card[]; remaining: Deck } {
-  const source = deck ?? [];
-  const drawn = source.slice(0, count);
-  const remaining = source.slice(count);
-  return { drawn, remaining };
-}
-
-/**
- * Forbidden-phase Joker fallback: when the GM "draws" a Joker for
- * the forbidden cell coordinate, the rules call for an "attribute
- * card" but don't define joker semantics for the forbidden marker.
- * v1 uses 'fire' as a deterministic fallback element coordinate.
- */
-const JOKER_FORBIDDEN_FALLBACK: ElementCard = {
-  kind: 'element',
-  element: 'fire',
-  value: 1,
-};
-
-function coerceToElementCard(card: Card): ElementCard {
-  return isElementCard(card) ? card : JOKER_FORBIDDEN_FALLBACK;
-}
-
-function allTeams(state: RoundState): TeamState[] {
-  const teams: TeamState[] = [];
-  for (const x of ELEMENT_AXIS) {
-    for (const y of ELEMENT_AXIS) {
-      teams.push(...state.grid[x][y]);
-    }
-  }
-  return teams;
-}
-
-function findTeam(state: RoundState, teamId: TeamId): TeamState | undefined {
-  return allTeams(state).find((team) => team.teamNumber === teamId);
-}
-
-function isTeamAlive(team: TeamState): boolean {
-  return team.players.some((player) => player.life > 0);
-}
-
-function updateTeam(state: RoundState, updated: TeamState): RoundState {
-  const { x, y } = updated.position;
-  return {
-    ...state,
-    grid: {
-      ...state.grid,
-      [x]: {
-        ...state.grid[x],
-        [y]: state.grid[x][y].map((team) =>
-          team.teamNumber === updated.teamNumber ? updated : team,
-        ),
-      },
-    },
-  } as RoundState;
-}
-
-function resolveMovementChoices(
-  state: RoundState,
-  movementChoices: readonly MovementChoice[],
-  round: number,
-  log: LogEntry[],
-): { state: RoundState; teamMoves: readonly TeamMove[] } {
-  let next = state;
-  const resolvedMoves: TeamMove[] = [];
-  const choicesByTeam = new Map<TeamId, MovementChoice>();
-  for (const choice of movementChoices) {
-    choicesByTeam.set(choice.teamId, choice);
-  }
-
-  const candidateIds = new Set<TeamId>(choicesByTeam.keys());
-  for (const team of allTeams(next)) {
-    if (!isTeamAlive(team)) continue;
-    if (team.cards.length === 0) {
-      candidateIds.add(team.teamNumber);
-    }
-  }
-
-  // Process every movement candidate in one team-number order so
-  // explicit submissions and emergency draws both stay deterministic
-  // regardless of submission order. This remains safe because
-  // movement later resolves each team's state independently.
-  const orderedTeamIds = [...candidateIds].sort((a, b) => a - b);
-  for (const teamId of orderedTeamIds) {
-    const team = findTeam(next, teamId);
-    if (team === undefined || !isTeamAlive(team)) continue;
-
-    const choice = choicesByTeam.get(teamId);
-    if (team.cards.length === 0) {
-      if (choice?.kind === 'explicit') {
-        throw new RangeError(
-          `Team ${teamId} cannot use an explicit movement choice with an empty hand.`,
-        );
-      }
-
-      const emergencyDraw = drawFromDeck(next.deck, 2);
-      next = { ...next, deck: emergencyDraw.remaining };
-      const [firstDrawnCard, secondDrawnCard] = emergencyDraw.drawn;
-      if (firstDrawnCard === undefined) {
-        log.push({
-          round,
-          phase: 'movement',
-          message: `Team ${teamId} had no cards in hand and the deck was exhausted`,
-        });
-        continue;
-      }
-
-      const replenishedTeam: TeamState = {
-        ...team,
-        cards: [...team.cards, ...emergencyDraw.drawn],
-      };
-      next = updateTeam(next, replenishedTeam);
-      log.push({
-        round,
-        phase: 'movement',
-        message: `Team ${teamId} drew ${emergencyDraw.drawn.length} card(s) for the empty-hand movement fallback`,
-      });
-      if (choice?.kind !== 'emergency-draw') {
-        log.push({
-          round,
-          phase: 'movement',
-          message: `Team ${teamId} had no movement submission after the empty-hand movement fallback draw`,
-        });
-        continue;
-      }
-
-      const selectedDrawIndex = choice.emergencyDrawPick ?? 0;
-      const selectedCard =
-        selectedDrawIndex === 1
-          ? (secondDrawnCard ?? firstDrawnCard)
-          : firstDrawnCard;
-
-      resolvedMoves.push({
-        teamId,
-        card: selectedCard,
-        intendedFacing: choice.intendedFacing,
-        ...(choice.gridSwapIndex !== undefined
-          ? { gridSwapIndex: choice.gridSwapIndex }
-          : {}),
-      });
-      continue;
-    }
-
-    if (choice === undefined) continue;
-    if (choice.kind === 'emergency-draw') {
-      const [firstHandCard] = team.cards;
-      if (firstHandCard === undefined) continue;
-
-      resolvedMoves.push({
-        teamId,
-        card: firstHandCard,
-        intendedFacing: choice.intendedFacing,
-        ...(choice.gridSwapIndex !== undefined
-          ? { gridSwapIndex: choice.gridSwapIndex }
-          : {}),
-      });
-      continue;
-    }
-
-    resolvedMoves.push({
-      teamId,
-      card: choice.card,
-      intendedFacing: choice.intendedFacing,
-      ...(choice.gridSwapIndex !== undefined
-        ? { gridSwapIndex: choice.gridSwapIndex }
-        : {}),
-    });
-  }
-
-  return { state: next, teamMoves: resolvedMoves };
 }
 
 /**
@@ -345,8 +137,9 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
     const resolvedMovement = resolveMovementChoices(
       movementInputState,
       inputs.movement.teamMoves,
-      round,
-      log,
+      (message) => {
+        log.push({ round, phase: 'movement', message });
+      },
     );
     const beforeMovement = resolvedMovement.state;
     next = advanceMovement(

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -616,6 +616,59 @@ describe('createSession', () => {
     expect(humanTeam?.facing).toBe('north');
   });
 
+  it('keeps the battle phase when the game ends during battle resolution', () => {
+    const decisiveStrategy: TeamStrategy = {
+      chooseBattlePlay(state, teamId) {
+        const team = findTeam(state, teamId);
+        return { card: team?.cards[0] ?? null };
+      },
+      chooseTeamMove() {
+        return null;
+      },
+      chooseRevivalAction() {
+        return null;
+      },
+    };
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 4,
+          cards: [fire5],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: fireFire,
+          life: 1,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [
+          1 as NumberToken,
+          { type: 'bot' as const, strategy: decisiveStrategy },
+        ],
+        [
+          2 as NumberToken,
+          { type: 'bot' as const, strategy: decisiveStrategy },
+        ],
+      ]),
+    });
+
+    const done = session.step();
+
+    expect(done.status).toBe('done');
+    expect(isGameOver(done.state)).toBe(true);
+    expect(done.state.phase).toBe('battle');
+    expect(done.state.forbiddenCells).toEqual([]);
+  });
+
   it('treats missing controls as human without throwing', () => {
     const state = stateWith({
       teams: [

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -1,0 +1,461 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONFIG } from '../config.ts';
+import {
+  createEmptyDroppedTokens,
+  createEmptyGrid,
+  isGameOver,
+  type RoundState,
+} from '../logic/round.ts';
+import { setupGame } from '../logic/setup.ts';
+import { randomStrategy } from '../strategy/random.ts';
+import type { TeamStrategy } from '../strategy/strategy.ts';
+import type { Card, ElementCard, JokerCard } from '../types/card.ts';
+import type { GridCoord, TeamState } from '../types/grid.ts';
+import { ELEMENT_AXIS } from '../types/grid.ts';
+import {
+  createLifeToken,
+  type NumberToken,
+  type TeamId,
+} from '../types/token.ts';
+import { createSession } from './session.ts';
+
+const fire1: ElementCard = { kind: 'element', element: 'fire', value: 1 };
+const fire5: ElementCard = { kind: 'element', element: 'fire', value: 5 };
+const water1: ElementCard = { kind: 'element', element: 'water', value: 1 };
+const water3: ElementCard = { kind: 'element', element: 'water', value: 3 };
+const wood1: ElementCard = { kind: 'element', element: 'wood', value: 1 };
+const wood4: ElementCard = { kind: 'element', element: 'wood', value: 4 };
+const joker: JokerCard = { kind: 'joker' };
+
+const fireFire: GridCoord = { x: 'fire', y: 'fire' };
+const woodWood: GridCoord = { x: 'wood', y: 'wood' };
+
+function stateWith(opts: {
+  teams: readonly TeamState[];
+  deck?: readonly Card[];
+  phase?: 'battle' | 'forbidden' | 'movement' | 'revival';
+  forbiddenCells?: readonly GridCoord[];
+}): RoundState {
+  let grid = createEmptyGrid();
+  for (const team of opts.teams) {
+    const { x, y } = team.position;
+    grid = {
+      ...grid,
+      [x]: { ...grid[x], [y]: [...grid[x][y], team] },
+    } as typeof grid;
+  }
+  return {
+    phase: opts.phase ?? 'battle',
+    round: 1,
+    grid,
+    forbiddenCells: opts.forbiddenCells ?? [],
+    deck: [...(opts.deck ?? [])],
+    graveyard: [],
+    droppedLifeTokens: createEmptyDroppedTokens(),
+  };
+}
+
+function makeTeam(opts: {
+  id: NumberToken;
+  position: GridCoord;
+  facing?: 'north' | 'east' | 'south' | 'west';
+  life?: number;
+  cards?: readonly Card[];
+  gridCards?: readonly [Card, Card];
+}): TeamState {
+  return {
+    teamNumber: opts.id,
+    position: opts.position,
+    facing: opts.facing ?? 'north',
+    cards: opts.cards ?? [],
+    gridCards: opts.gridCards ?? [fire1, water1],
+    players: [{ life: createLifeToken(opts.life ?? 4) }],
+  };
+}
+
+function allTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+function findTeam(state: RoundState, teamId: TeamId): TeamState | undefined {
+  return allTeams(state).find((team) => team.teamNumber === teamId);
+}
+
+describe('createSession', () => {
+  it('runs an all-bot round without awaiting human input', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          facing: 'east',
+          cards: [fire5],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5, wood4, water3, joker],
+    });
+    const session = createSession(state, {
+      controls: new Map<
+        TeamId,
+        {
+          readonly type: 'bot';
+          readonly strategy: ReturnType<typeof randomStrategy>;
+        }
+      >([
+        [1 as NumberToken, { type: 'bot', strategy: randomStrategy(1) }],
+        [2 as NumberToken, { type: 'bot', strategy: randomStrategy(2) }],
+      ]),
+    });
+
+    const step = session.step();
+
+    expect(step.status).toBe('done');
+    expect(step.state.round).toBe(2);
+    expect(step.state.phase).toBe('battle');
+  });
+
+  it('resolves empty-hand bot fallback movement without awaiting humans', () => {
+    const fallbackStrategy: TeamStrategy = {
+      chooseBattlePlay() {
+        return { card: null };
+      },
+      chooseTeamMove(state, teamId) {
+        const team = findTeam(state, teamId);
+        if (team === undefined) {
+          return null;
+        }
+        if (team.cards.length === 0) {
+          return {
+            kind: 'emergency-draw',
+            intendedFacing: 'east',
+            gridSwapIndex: 0,
+            emergencyDrawPick: 1,
+          };
+        }
+        return {
+          kind: 'explicit',
+          card: team.cards[0] as Card,
+          intendedFacing: 'east',
+          gridSwapIndex: 0,
+        };
+      },
+      chooseRevivalAction() {
+        return null;
+      },
+    };
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [fire5],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [fire1, water1, water3, wood1, fire5],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [
+          1 as NumberToken,
+          { type: 'bot' as const, strategy: fallbackStrategy },
+        ],
+        [
+          2 as NumberToken,
+          { type: 'bot' as const, strategy: fallbackStrategy },
+        ],
+      ]),
+    });
+
+    const step = session.step();
+
+    expect(step.status).toBe('done');
+    const team = findTeam(step.state, 1 as NumberToken);
+    expect(team?.cards).toHaveLength(1);
+    expect(team?.cards[0]).toEqual(wood1);
+    expect(team?.gridCards?.[0]).toEqual(fire5);
+  });
+
+  it('awaits battle, movement, and revival for an all-human round', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          facing: 'east',
+          cards: [fire5],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5, wood4, water3, joker],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [2 as NumberToken, { type: 'human' as const }],
+      ]),
+    });
+
+    const battle = session.step();
+    expect(battle).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'battle', humanTeams: [1, 2] },
+    });
+
+    const movement = session.step({
+      battlePlays: new Map([
+        [1 as NumberToken, { teamId: 1 as NumberToken, card: null }],
+        [2 as NumberToken, { teamId: 2 as NumberToken, card: null }],
+      ]),
+    });
+    expect(movement).toMatchObject({
+      status: 'awaiting',
+      request: {
+        phase: 'movement',
+        humanTeams: [1, 2],
+        movementAttribute: 'fire',
+      },
+    });
+
+    const revival = session.step({
+      teamMoves: new Map([
+        [
+          1 as NumberToken,
+          {
+            teamId: 1 as NumberToken,
+            card: fire5,
+            intendedFacing: 'east',
+          },
+        ],
+        [
+          2 as NumberToken,
+          {
+            teamId: 2 as NumberToken,
+            card: wood1,
+            intendedFacing: 'north',
+          },
+        ],
+      ]),
+    });
+    expect(revival).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'revival', humanTeams: [1] },
+    });
+
+    const done = session.step({
+      revivalActions: new Map([
+        [1 as NumberToken, { type: 'charge-cards' as const }],
+      ]),
+    });
+    expect(done.status).toBe('done');
+    expect(done.state.round).toBe(2);
+    expect(done.state.phase).toBe('battle');
+  });
+
+  it('awaits only human-controlled teams in a mixed session', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          facing: 'east',
+          cards: [fire5],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5, wood4, water3, joker],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [
+          2 as NumberToken,
+          { type: 'bot' as const, strategy: randomStrategy(2) },
+        ],
+      ]),
+    });
+
+    const battle = session.step();
+    expect(battle).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'battle', humanTeams: [1] },
+    });
+
+    const movement = session.step({
+      battlePlays: new Map([
+        [1 as NumberToken, { teamId: 1 as NumberToken, card: null }],
+      ]),
+    });
+    expect(movement).toMatchObject({
+      status: 'awaiting',
+      request: {
+        phase: 'movement',
+        humanTeams: [1],
+        movementAttribute: 'fire',
+      },
+    });
+
+    const revival = session.step({
+      teamMoves: new Map([
+        [
+          1 as NumberToken,
+          {
+            teamId: 1 as NumberToken,
+            card: fire5,
+            intendedFacing: 'east',
+          },
+        ],
+      ]),
+    });
+    expect(revival).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'revival', humanTeams: [1] },
+    });
+  });
+
+  it('treats missing controls as human without throwing', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [fire5],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+        }),
+      ],
+      deck: [water1, fire1, fire5],
+    });
+
+    const session = createSession(state, { controls: new Map() });
+
+    const step = session.step();
+
+    expect(step).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'battle', humanTeams: [1, 2] },
+    });
+  });
+
+  it('pre-draws movement fallback cards for human teams with empty hands', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5, wood1, wood4],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [2 as NumberToken, { type: 'human' as const }],
+      ]),
+    });
+
+    session.step();
+    const movement = session.step({
+      battlePlays: new Map([
+        [1 as NumberToken, { teamId: 1 as NumberToken, card: null }],
+        [2 as NumberToken, { teamId: 2 as NumberToken, card: null }],
+      ]),
+    });
+
+    expect(movement).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'movement', humanTeams: [1, 2] },
+    });
+    const team = allTeams(movement.state).find(
+      (entry) => entry.teamNumber === 1,
+    );
+    expect(team?.cards).toEqual([wood1, wood4]);
+  });
+
+  it('keeps returning done after the game is already over', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 4,
+          cards: [fire5],
+        }),
+      ],
+    });
+    const session = createSession(state, { controls: new Map() });
+
+    const first = session.step();
+    const second = session.step();
+
+    expect(first).toEqual({ status: 'done', state: state });
+    expect(second).toEqual({ status: 'done', state: state });
+  });
+
+  it('can drive a short multi-round all-bot smoke run to game over', () => {
+    const initial = setupGame({ playerCount: 6, seed: 7 }, DEFAULT_CONFIG);
+    const controls = new Map<
+      TeamId,
+      {
+        readonly type: 'bot';
+        readonly strategy: ReturnType<typeof randomStrategy>;
+      }
+    >();
+    for (const team of allTeams(initial)) {
+      controls.set(team.teamNumber, {
+        type: 'bot',
+        strategy: randomStrategy(team.teamNumber),
+      });
+    }
+    const session = createSession(initial, { controls });
+
+    for (let i = 0; i < 100 && !isGameOver(session.state); i++) {
+      const step = session.step();
+      expect(step.status).toBe('done');
+    }
+
+    expect(isGameOver(session.state)).toBe(true);
+  });
+});

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -3,6 +3,7 @@ import { DEFAULT_CONFIG } from '../config.ts';
 import {
   createEmptyDroppedTokens,
   createEmptyGrid,
+  type DroppedTokens,
   isGameOver,
   type RoundState,
 } from '../logic/round.ts';
@@ -33,6 +34,7 @@ const woodWood: GridCoord = { x: 'wood', y: 'wood' };
 function stateWith(opts: {
   teams: readonly TeamState[];
   deck?: readonly Card[];
+  droppedLifeTokens?: DroppedTokens;
   phase?: 'battle' | 'forbidden' | 'movement' | 'revival';
   forbiddenCells?: readonly GridCoord[];
 }): RoundState {
@@ -51,7 +53,7 @@ function stateWith(opts: {
     forbiddenCells: opts.forbiddenCells ?? [],
     deck: [...(opts.deck ?? [])],
     graveyard: [],
-    droppedLifeTokens: createEmptyDroppedTokens(),
+    droppedLifeTokens: opts.droppedLifeTokens ?? createEmptyDroppedTokens(),
   };
 }
 
@@ -193,6 +195,74 @@ describe('createSession', () => {
     expect(team?.cards).toHaveLength(1);
     expect(team?.cards[0]).toEqual(wood1);
     expect(team?.gridCards?.[0]).toEqual(fire5);
+  });
+
+  it('preserves empty-hand movement fallback draw order across controls', () => {
+    const fallbackStrategy: TeamStrategy = {
+      chooseBattlePlay() {
+        return { card: null };
+      },
+      chooseTeamMove() {
+        return {
+          kind: 'emergency-draw',
+          intendedFacing: 'east',
+          gridSwapIndex: 0,
+          emergencyDrawPick: 0,
+        };
+      },
+      chooseRevivalAction() {
+        return null;
+      },
+    };
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [fire1, water1, water3, wood1, fire5, joker, wood4],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [
+          1 as NumberToken,
+          { type: 'bot' as const, strategy: fallbackStrategy },
+        ],
+        [2 as NumberToken, { type: 'human' as const }],
+      ]),
+    });
+
+    const battle = session.step();
+    expect(battle).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'battle', humanTeams: [2] },
+    });
+
+    const movement = session.step({
+      battlePlays: new Map([
+        [2 as NumberToken, { teamId: 2 as NumberToken, card: null }],
+      ]),
+    });
+
+    expect(movement).toMatchObject({
+      status: 'awaiting',
+      request: {
+        phase: 'movement',
+        humanTeams: [2],
+        movementAttribute: 'water',
+      },
+    });
+    const humanTeam = findTeam(movement.state, 2 as NumberToken);
+    expect(humanTeam?.cards).toEqual([joker, wood4]);
   });
 
   it('awaits battle, movement, and revival for an all-human round', () => {
@@ -342,6 +412,208 @@ describe('createSession', () => {
       status: 'awaiting',
       request: { phase: 'revival', humanTeams: [1] },
     });
+  });
+
+  it('ignores revival inputs for bot-controlled teams', () => {
+    const dropped = createEmptyDroppedTokens();
+    const droppedLifeTokens: DroppedTokens = {
+      ...dropped,
+      fire: { ...dropped.fire, fire: 1 },
+      wood: { ...dropped.wood, wood: 1 },
+    };
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 3,
+          cards: [fire5],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          life: 3,
+          cards: [wood1],
+        }),
+      ],
+      deck: [fire1, water1, water3],
+      droppedLifeTokens,
+      phase: 'revival',
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [
+          2 as NumberToken,
+          {
+            type: 'bot' as const,
+            strategy: {
+              chooseBattlePlay() {
+                return { card: null };
+              },
+              chooseTeamMove() {
+                return null;
+              },
+              chooseRevivalAction() {
+                return null;
+              },
+            },
+          },
+        ],
+      ]),
+    });
+
+    const revival = session.step();
+    expect(revival).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'revival', humanTeams: [1] },
+    });
+
+    const done = session.step({
+      revivalActions: new Map([
+        [1 as NumberToken, { type: 'charge-cards' as const }],
+        [2 as NumberToken, { type: 'charge-life' as const }],
+      ]),
+    });
+
+    expect(done.status).toBe('done');
+    const botTeam = findTeam(done.state, 2 as NumberToken);
+    expect(botTeam?.players[0]?.life).toBe(3);
+    expect(done.state.droppedLifeTokens?.wood.wood).toBe(1);
+  });
+
+  it('keeps awaiting revival until every human team submits an action', () => {
+    const dropped = createEmptyDroppedTokens();
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 3,
+          cards: [fire5],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          life: 3,
+          cards: [wood1],
+        }),
+      ],
+      deck: [fire1, water1, water3],
+      droppedLifeTokens: {
+        ...dropped,
+        fire: { ...dropped.fire, fire: 1 },
+      },
+      phase: 'revival',
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [2 as NumberToken, { type: 'human' as const }],
+      ]),
+    });
+
+    const revival = session.step();
+    expect(revival).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'revival', humanTeams: [1] },
+    });
+
+    const stillAwaiting = session.step({
+      revivalActions: new Map(),
+    });
+    expect(stillAwaiting).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'revival', humanTeams: [1] },
+    });
+
+    const done = session.step({
+      revivalActions: new Map([
+        [1 as NumberToken, { type: 'charge-life' as const }],
+      ]),
+    });
+    expect(done.status).toBe('done');
+    expect(done.state.droppedLifeTokens?.fire.fire).toBe(0);
+  });
+
+  it('ignores explicit movement cards that are not in the team hand', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [water3],
+          gridCards: [wood1, fire1],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood4],
+          gridCards: [fire5, wood1],
+        }),
+      ],
+      deck: [water1, water1, fire1],
+    });
+    const session = createSession(state, {
+      controls: new Map([
+        [1 as NumberToken, { type: 'human' as const }],
+        [
+          2 as NumberToken,
+          {
+            type: 'bot' as const,
+            strategy: {
+              chooseBattlePlay() {
+                return { card: null };
+              },
+              chooseTeamMove() {
+                return null;
+              },
+              chooseRevivalAction() {
+                return null;
+              },
+            },
+          },
+        ],
+      ]),
+    });
+
+    expect(session.step()).toMatchObject({
+      status: 'awaiting',
+      request: { phase: 'battle', humanTeams: [1] },
+    });
+
+    const movement = session.step({
+      battlePlays: new Map([
+        [1 as NumberToken, { teamId: 1 as NumberToken, card: null }],
+      ]),
+    });
+    expect(movement).toMatchObject({
+      status: 'awaiting',
+      request: {
+        phase: 'movement',
+        humanTeams: [1],
+        movementAttribute: 'fire',
+      },
+    });
+
+    const done = session.step({
+      teamMoves: new Map([
+        [
+          1 as NumberToken,
+          {
+            teamId: 1 as NumberToken,
+            card: fire5,
+            intendedFacing: 'east',
+          },
+        ],
+      ]),
+    });
+
+    expect(done.status).toBe('done');
+    const humanTeam = findTeam(done.state, 1 as NumberToken);
+    expect(humanTeam?.cards).toEqual([water3]);
+    expect(humanTeam?.gridCards).toEqual([wood1, fire1]);
+    expect(humanTeam?.facing).toBe('north');
   });
 
   it('treats missing controls as human without throwing', () => {

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -129,6 +129,47 @@ describe('createSession', () => {
     expect(step.state.phase).toBe('battle');
   });
 
+  it('keeps returning done after a round completes', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          facing: 'east',
+          cards: [fire5],
+          gridCards: [wood1, water3],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood1],
+          gridCards: [fire1, wood4],
+        }),
+      ],
+      deck: [water1, fire1, fire5, wood4, water3, joker],
+    });
+    const session = createSession(state, {
+      controls: new Map<
+        TeamId,
+        {
+          readonly type: 'bot';
+          readonly strategy: ReturnType<typeof randomStrategy>;
+        }
+      >([
+        [1 as NumberToken, { type: 'bot', strategy: randomStrategy(1) }],
+        [2 as NumberToken, { type: 'bot', strategy: randomStrategy(2) }],
+      ]),
+    });
+
+    const first = session.step();
+    const second = session.step();
+
+    expect(first.status).toBe('done');
+    expect(first.state.round).toBe(2);
+    expect(first.state.phase).toBe('battle');
+    expect(second).toEqual(first);
+  });
+
   it('resolves empty-hand bot fallback movement without awaiting humans', () => {
     const fallbackStrategy: TeamStrategy = {
       chooseBattlePlay() {
@@ -774,13 +815,15 @@ describe('createSession', () => {
         strategy: randomStrategy(team.teamNumber),
       });
     }
-    const session = createSession(initial, { controls });
+    let state = initial;
 
-    for (let i = 0; i < 100 && !isGameOver(session.state); i++) {
+    for (let i = 0; i < 100 && !isGameOver(state); i++) {
+      const session = createSession(state, { controls });
       const step = session.step();
       expect(step.status).toBe('done');
+      state = step.state;
     }
 
-    expect(isGameOver(session.state)).toBe(true);
+    expect(isGameOver(state)).toBe(true);
   });
 });

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -657,6 +657,68 @@ describe('createSession', () => {
     expect(humanTeam?.facing).toBe('north');
   });
 
+  it('throws when a bot strategy returns an explicit movement card not in hand', () => {
+    const state = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          cards: [water3],
+          gridCards: [wood1, fire1],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          cards: [wood4],
+          gridCards: [fire5, wood1],
+        }),
+      ],
+      deck: [water1, water1, fire1],
+    });
+    const invalidBotStrategy: TeamStrategy = {
+      chooseBattlePlay() {
+        return { card: null };
+      },
+      chooseTeamMove() {
+        return {
+          kind: 'explicit',
+          card: fire5,
+          intendedFacing: 'east',
+        };
+      },
+      chooseRevivalAction() {
+        return null;
+      },
+    };
+    const passiveBotStrategy: TeamStrategy = {
+      chooseBattlePlay() {
+        return { card: null };
+      },
+      chooseTeamMove() {
+        return null;
+      },
+      chooseRevivalAction() {
+        return null;
+      },
+    };
+    const session = createSession(state, {
+      controls: new Map([
+        [
+          1 as NumberToken,
+          { type: 'bot' as const, strategy: invalidBotStrategy },
+        ],
+        [
+          2 as NumberToken,
+          { type: 'bot' as const, strategy: passiveBotStrategy },
+        ],
+      ]),
+    });
+
+    expect(() => session.step()).toThrowError(
+      'Team 1 cannot play fire 5 for movement: not in hand.',
+    );
+  });
+
   it('keeps the battle phase when the game ends during battle resolution', () => {
     const decisiveStrategy: TeamStrategy = {
       chooseBattlePlay(state, teamId) {

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -58,7 +58,6 @@ export type SessionStep =
   | { readonly status: 'done'; readonly state: RoundState };
 
 const DEFAULT_HUMAN_CONTROL: TeamControl = { type: 'human' };
-
 function controlFor(
   controls: ReadonlyMap<TeamId, TeamControl>,
   teamId: TeamId,
@@ -74,6 +73,12 @@ function sortedLivingTeams(
   return allTeams(state)
     .filter((team) => isTeamAlive(team))
     .filter((team) => controlFor(controls, team.teamNumber).type === type)
+    .sort((left, right) => left.teamNumber - right.teamNumber);
+}
+
+function sortedAllLivingTeams(state: RoundState): TeamState[] {
+  return allTeams(state)
+    .filter((team) => isTeamAlive(team))
     .sort((left, right) => left.teamNumber - right.teamNumber);
 }
 
@@ -113,25 +118,78 @@ function hasCompleteInputs<T>(
   return values !== undefined && teamIds.every((teamId) => values.has(teamId));
 }
 
-function primeHumanMovementHands(
+function primeMovementFallbackHands(
   state: RoundState,
   controls: ReadonlyMap<TeamId, TeamControl>,
-): RoundState {
+): {
+  readonly state: RoundState;
+  readonly preparedBotChoices: readonly MovementChoice[];
+  readonly preparedBotTeams: ReadonlySet<TeamId>;
+} {
   let next = state;
-  const humanTeams = sortedLivingTeams(next, controls, 'human');
-  for (const team of humanTeams) {
-    if (team.cards.length > 0) continue;
+  const preparedBotChoices: MovementChoice[] = [];
+  const preparedBotTeams = new Set<TeamId>();
+
+  for (const team of sortedAllLivingTeams(next)) {
+    if (team.cards.length > 0) {
+      continue;
+    }
+
     const latestTeam = findTeam(next, team.teamNumber);
-    if (latestTeam === undefined || latestTeam.cards.length > 0) continue;
+    if (latestTeam === undefined || latestTeam.cards.length > 0) {
+      continue;
+    }
+
+    const control = controlFor(controls, team.teamNumber);
+    let botMovementChoice: ReturnType<TeamStrategy['chooseTeamMove']> = null;
+    if (control.type === 'bot') {
+      preparedBotTeams.add(team.teamNumber);
+      const movement = control.strategy.chooseTeamMove(next, team.teamNumber);
+      if (movement?.kind === 'explicit') {
+        throw new RangeError(
+          `Team ${team.teamNumber} cannot use an explicit movement choice with an empty hand.`,
+        );
+      }
+      botMovementChoice = movement;
+    }
+
     const draw = drawFromDeck(next.deck, 2);
-    if (draw.drawn.length === 0) continue;
+    if (draw.drawn.length === 0) {
+      continue;
+    }
+    const [firstDrawnCard, secondDrawnCard] = draw.drawn;
+
     const updated: TeamState = {
       ...latestTeam,
       cards: [...latestTeam.cards, ...draw.drawn],
     };
     next = updateTeam({ ...next, deck: draw.remaining }, updated);
+
+    if (botMovementChoice?.kind === 'emergency-draw') {
+      if (firstDrawnCard === undefined) {
+        continue;
+      }
+      const selectedCard =
+        botMovementChoice.emergencyDrawPick === 1
+          ? (secondDrawnCard ?? firstDrawnCard)
+          : firstDrawnCard;
+      preparedBotChoices.push({
+        kind: 'explicit',
+        teamId: team.teamNumber,
+        card: selectedCard,
+        intendedFacing: botMovementChoice.intendedFacing,
+        ...(botMovementChoice.gridSwapIndex !== undefined
+          ? { gridSwapIndex: botMovementChoice.gridSwapIndex }
+          : {}),
+      });
+    }
   }
-  return next;
+
+  return {
+    state: next,
+    preparedBotChoices,
+    preparedBotTeams,
+  };
 }
 
 function humanMovementTeams(
@@ -153,6 +211,8 @@ export function createSession(
   let current = initial;
   let pendingRequest: HumanInputRequest | null = null;
   let pendingMovementAttribute: Element | null = null;
+  let pendingPreparedBotMovementChoices: readonly MovementChoice[] = [];
+  let pendingPreparedBotMovementTeams = new Set<TeamId>();
 
   function applyBattle(
     battlePlays: ReadonlyMap<TeamId, BattlePlay> | undefined,
@@ -183,6 +243,9 @@ export function createSession(
       return humanMovementTeams(current, config.controls);
     }
 
+    pendingPreparedBotMovementChoices = [];
+    pendingPreparedBotMovementTeams = new Set<TeamId>();
+
     const moveDraw = drawFromDeck(current.deck, 1);
     if (moveDraw.drawn.length < 1) {
       current = { ...current, phase: 'revival' };
@@ -192,7 +255,7 @@ export function createSession(
 
     const attrCard = coerceToElementCard(moveDraw.drawn[0] as Card);
     pendingMovementAttribute = attrCard.element;
-    current = primeHumanMovementHands(
+    const prepared = primeMovementFallbackHands(
       {
         ...current,
         deck: moveDraw.remaining,
@@ -200,6 +263,9 @@ export function createSession(
       },
       config.controls,
     );
+    current = prepared.state;
+    pendingPreparedBotMovementChoices = prepared.preparedBotChoices;
+    pendingPreparedBotMovementTeams = new Set(prepared.preparedBotTeams);
     return humanMovementTeams(current, config.controls);
   }
 
@@ -211,7 +277,9 @@ export function createSession(
       throw new Error('Movement attribute missing while resolving movement.');
     }
 
-    const movementChoices: MovementChoice[] = [];
+    const movementChoices: MovementChoice[] = [
+      ...pendingPreparedBotMovementChoices,
+    ];
     for (const teamId of humanTeams) {
       const move = teamMoves?.get(teamId);
       if (move === undefined) continue;
@@ -227,6 +295,9 @@ export function createSession(
     }
 
     for (const team of sortedLivingTeams(current, config.controls, 'bot')) {
+      if (pendingPreparedBotMovementTeams.has(team.teamNumber)) {
+        continue;
+      }
       const movement = teamControlStrategy(team.teamNumber).chooseTeamMove(
         current,
         team.teamNumber,
@@ -245,12 +316,17 @@ export function createSession(
       resolved.teamMoves,
     );
     pendingMovementAttribute = null;
+    pendingPreparedBotMovementChoices = [];
+    pendingPreparedBotMovementTeams = new Set<TeamId>();
   }
 
   function applyRevival(
     revivalActions: ReadonlyMap<TeamId, RevivalAction> | undefined,
   ): void {
     const choices = new Map<TeamId, RevivalAction>();
+    const eligibleHumanTeams = new Set(
+      eligibleRevivalHumanTeams(current, config.controls),
+    );
 
     for (const team of sortedLivingTeams(current, config.controls, 'bot')) {
       const revival = teamControlStrategy(team.teamNumber).chooseRevivalAction(
@@ -263,6 +339,9 @@ export function createSession(
     }
 
     for (const [teamId, action] of revivalActions ?? new Map()) {
+      if (!eligibleHumanTeams.has(teamId)) {
+        continue;
+      }
       choices.set(teamId, action);
     }
 
@@ -322,7 +401,12 @@ export function createSession(
             }
             break;
           case 'revival':
-            if (humanInputs?.revivalActions === undefined) {
+            if (
+              !hasCompleteInputs(
+                pendingRequest.humanTeams,
+                humanInputs?.revivalActions,
+              )
+            ) {
               return {
                 status: 'awaiting',
                 request: pendingRequest,
@@ -385,10 +469,7 @@ export function createSession(
               current,
               config.controls,
             );
-            if (
-              humanInputs?.revivalActions === undefined &&
-              humanTeams.length > 0
-            ) {
+            if (!hasCompleteInputs(humanTeams, humanInputs?.revivalActions)) {
               return awaiting({ phase: 'revival', humanTeams });
             }
             applyRevival(humanInputs?.revivalActions);

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -2,10 +2,14 @@ import { DEFAULT_CONFIG, type GameConfig } from '../config.ts';
 import type { BattlePlay } from '../logic/battle.ts';
 import { resolveBattlePhase } from '../logic/battle.ts';
 import {
+  allTeams,
   coerceToElementCard,
   drawFromDeck,
+  findTeam,
+  isTeamAlive,
   type MovementChoice,
   resolveMovementChoices,
+  updateTeam,
 } from '../logic/phase-helpers.ts';
 import {
   advanceForbidden,
@@ -16,13 +20,9 @@ import {
   type RoundState,
   type TeamMove,
 } from '../logic/round.ts';
-import {
-  findTeam,
-  isTeamAlive,
-  type TeamStrategy,
-} from '../strategy/strategy.ts';
+import type { TeamStrategy } from '../strategy/strategy.ts';
 import type { Card, Element } from '../types/card.ts';
-import { ELEMENT_AXIS, type TeamState } from '../types/grid.ts';
+import type { TeamState } from '../types/grid.ts';
 import type { TeamId } from '../types/token.ts';
 
 export type TeamControl =
@@ -58,32 +58,6 @@ export type SessionStep =
   | { readonly status: 'done'; readonly state: RoundState };
 
 const DEFAULT_HUMAN_CONTROL: TeamControl = { type: 'human' };
-
-function allTeams(state: RoundState): TeamState[] {
-  const teams: TeamState[] = [];
-  for (const x of ELEMENT_AXIS) {
-    for (const y of ELEMENT_AXIS) {
-      teams.push(...state.grid[x][y]);
-    }
-  }
-  return teams;
-}
-
-function updateTeam(state: RoundState, updated: TeamState): RoundState {
-  const { x, y } = updated.position;
-  return {
-    ...state,
-    grid: {
-      ...state.grid,
-      [x]: {
-        ...state.grid[x],
-        [y]: state.grid[x][y].map((team) =>
-          team.teamNumber === updated.teamNumber ? updated : team,
-        ),
-      },
-    },
-  } as RoundState;
-}
 
 function controlFor(
   controls: ReadonlyMap<TeamId, TeamControl>,

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -209,6 +209,7 @@ export function createSession(
   readonly step: (humanInputs?: HumanInputs) => SessionStep;
 } {
   let current = initial;
+  let completed = false;
   let pendingRequest: HumanInputRequest | null = null;
   let pendingMovementAttribute: Element | null = null;
   let pendingPreparedBotMovementChoices: readonly MovementChoice[] = [];
@@ -374,7 +375,8 @@ export function createSession(
       return current;
     },
     step(humanInputs) {
-      if (isGameOver(current)) {
+      if (completed || isGameOver(current)) {
+        completed = true;
         return { status: 'done', state: current };
       }
 
@@ -428,6 +430,7 @@ export function createSession(
 
       while (true) {
         if (isGameOver(current)) {
+          completed = true;
           return { status: 'done', state: current };
         }
 
@@ -481,6 +484,7 @@ export function createSession(
               return awaiting({ phase: 'revival', humanTeams });
             }
             applyRevival(humanInputs?.revivalActions);
+            completed = true;
             return { status: 'done', state: current };
           }
         }

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -1,0 +1,427 @@
+import { DEFAULT_CONFIG, type GameConfig } from '../config.ts';
+import type { BattlePlay } from '../logic/battle.ts';
+import { resolveBattlePhase } from '../logic/battle.ts';
+import {
+  coerceToElementCard,
+  drawFromDeck,
+  type MovementChoice,
+  resolveMovementChoices,
+} from '../logic/phase-helpers.ts';
+import {
+  advanceForbidden,
+  advanceMovement,
+  advanceRevival,
+  isGameOver,
+  type RevivalAction,
+  type RoundState,
+  type TeamMove,
+} from '../logic/round.ts';
+import {
+  findTeam,
+  isTeamAlive,
+  type TeamStrategy,
+} from '../strategy/strategy.ts';
+import type { Card, Element } from '../types/card.ts';
+import { ELEMENT_AXIS, type TeamState } from '../types/grid.ts';
+import type { TeamId } from '../types/token.ts';
+
+export type TeamControl =
+  | { readonly type: 'human' }
+  | { readonly type: 'bot'; readonly strategy: TeamStrategy };
+
+export type SessionConfig = {
+  readonly controls: ReadonlyMap<TeamId, TeamControl>;
+  readonly gameConfig?: GameConfig;
+};
+
+export type HumanInputRequest =
+  | { readonly phase: 'battle'; readonly humanTeams: readonly TeamId[] }
+  | {
+      readonly phase: 'movement';
+      readonly humanTeams: readonly TeamId[];
+      readonly movementAttribute: Element;
+    }
+  | { readonly phase: 'revival'; readonly humanTeams: readonly TeamId[] };
+
+export type HumanInputs = {
+  readonly battlePlays?: ReadonlyMap<TeamId, BattlePlay>;
+  readonly teamMoves?: ReadonlyMap<TeamId, TeamMove>;
+  readonly revivalActions?: ReadonlyMap<TeamId, RevivalAction>;
+};
+
+export type SessionStep =
+  | {
+      readonly status: 'awaiting';
+      readonly request: HumanInputRequest;
+      readonly state: RoundState;
+    }
+  | { readonly status: 'done'; readonly state: RoundState };
+
+const DEFAULT_HUMAN_CONTROL: TeamControl = { type: 'human' };
+
+function allTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of ELEMENT_AXIS) {
+    for (const y of ELEMENT_AXIS) {
+      teams.push(...state.grid[x][y]);
+    }
+  }
+  return teams;
+}
+
+function updateTeam(state: RoundState, updated: TeamState): RoundState {
+  const { x, y } = updated.position;
+  return {
+    ...state,
+    grid: {
+      ...state.grid,
+      [x]: {
+        ...state.grid[x],
+        [y]: state.grid[x][y].map((team) =>
+          team.teamNumber === updated.teamNumber ? updated : team,
+        ),
+      },
+    },
+  } as RoundState;
+}
+
+function controlFor(
+  controls: ReadonlyMap<TeamId, TeamControl>,
+  teamId: TeamId,
+): TeamControl {
+  return controls.get(teamId) ?? DEFAULT_HUMAN_CONTROL;
+}
+
+function sortedLivingTeams(
+  state: RoundState,
+  controls: ReadonlyMap<TeamId, TeamControl>,
+  type: TeamControl['type'],
+): TeamState[] {
+  return allTeams(state)
+    .filter((team) => isTeamAlive(team))
+    .filter((team) => controlFor(controls, team.teamNumber).type === type)
+    .sort((left, right) => left.teamNumber - right.teamNumber);
+}
+
+function humanBattleTeams(
+  state: RoundState,
+  controls: ReadonlyMap<TeamId, TeamControl>,
+): readonly TeamId[] {
+  return sortedLivingTeams(state, controls, 'human').map(
+    (team) => team.teamNumber,
+  );
+}
+
+function eligibleRevivalHumanTeams(
+  state: RoundState,
+  controls: ReadonlyMap<TeamId, TeamControl>,
+): readonly TeamId[] {
+  return sortedLivingTeams(state, controls, 'human')
+    .filter((team) => {
+      const dropped =
+        state.droppedLifeTokens?.[team.position.x]?.[team.position.y] ?? 0;
+      if (dropped <= 0) return false;
+      const cohabitants = state.grid[team.position.x][team.position.y].filter(
+        (other) => other.teamNumber !== team.teamNumber,
+      );
+      return cohabitants.length === 0;
+    })
+    .map((team) => team.teamNumber);
+}
+
+function hasCompleteInputs<T>(
+  teamIds: readonly TeamId[],
+  values: ReadonlyMap<TeamId, T> | undefined,
+): boolean {
+  if (teamIds.length === 0) {
+    return true;
+  }
+  return values !== undefined && teamIds.every((teamId) => values.has(teamId));
+}
+
+function primeHumanMovementHands(
+  state: RoundState,
+  controls: ReadonlyMap<TeamId, TeamControl>,
+): RoundState {
+  let next = state;
+  const humanTeams = sortedLivingTeams(next, controls, 'human');
+  for (const team of humanTeams) {
+    if (team.cards.length > 0) continue;
+    const latestTeam = findTeam(next, team.teamNumber);
+    if (latestTeam === undefined || latestTeam.cards.length > 0) continue;
+    const draw = drawFromDeck(next.deck, 2);
+    if (draw.drawn.length === 0) continue;
+    const updated: TeamState = {
+      ...latestTeam,
+      cards: [...latestTeam.cards, ...draw.drawn],
+    };
+    next = updateTeam({ ...next, deck: draw.remaining }, updated);
+  }
+  return next;
+}
+
+function humanMovementTeams(
+  state: RoundState,
+  controls: ReadonlyMap<TeamId, TeamControl>,
+): readonly TeamId[] {
+  return sortedLivingTeams(state, controls, 'human')
+    .filter((team) => team.cards.length > 0)
+    .map((team) => team.teamNumber);
+}
+
+export function createSession(
+  initial: RoundState,
+  config: SessionConfig,
+): {
+  readonly state: RoundState;
+  readonly step: (humanInputs?: HumanInputs) => SessionStep;
+} {
+  let current = initial;
+  let pendingRequest: HumanInputRequest | null = null;
+  let pendingMovementAttribute: Element | null = null;
+
+  function applyBattle(
+    battlePlays: ReadonlyMap<TeamId, BattlePlay> | undefined,
+  ): void {
+    const plays: BattlePlay[] = [];
+    for (const team of allTeams(current)) {
+      if (!isTeamAlive(team)) continue;
+      const teamId = team.teamNumber;
+      const control = controlFor(config.controls, teamId);
+      if (control.type === 'human') {
+        const play = battlePlays?.get(teamId) ?? { teamId, card: null };
+        plays.push({ teamId, card: play.card });
+        continue;
+      }
+      const battle = control.strategy.chooseBattlePlay(current, teamId);
+      plays.push({ teamId, card: battle.card });
+    }
+
+    current = {
+      ...resolveBattlePhase(current, plays, config.gameConfig ?? DEFAULT_CONFIG)
+        .state,
+      phase: 'forbidden',
+    };
+  }
+
+  function prepareMovement(): readonly TeamId[] {
+    if (pendingMovementAttribute !== null) {
+      return humanMovementTeams(current, config.controls);
+    }
+
+    const moveDraw = drawFromDeck(current.deck, 1);
+    if (moveDraw.drawn.length < 1) {
+      current = { ...current, phase: 'revival' };
+      pendingMovementAttribute = null;
+      return [];
+    }
+
+    const attrCard = coerceToElementCard(moveDraw.drawn[0] as Card);
+    pendingMovementAttribute = attrCard.element;
+    current = primeHumanMovementHands(
+      {
+        ...current,
+        deck: moveDraw.remaining,
+        phase: 'movement',
+      },
+      config.controls,
+    );
+    return humanMovementTeams(current, config.controls);
+  }
+
+  function applyMovement(
+    teamMoves: ReadonlyMap<TeamId, TeamMove> | undefined,
+    humanTeams: readonly TeamId[],
+  ): void {
+    if (pendingMovementAttribute === null) {
+      throw new Error('Movement attribute missing while resolving movement.');
+    }
+
+    const movementChoices: MovementChoice[] = [];
+    for (const teamId of humanTeams) {
+      const move = teamMoves?.get(teamId);
+      if (move === undefined) continue;
+      movementChoices.push({
+        kind: 'explicit',
+        teamId,
+        card: move.card,
+        intendedFacing: move.intendedFacing,
+        ...(move.gridSwapIndex !== undefined
+          ? { gridSwapIndex: move.gridSwapIndex }
+          : {}),
+      });
+    }
+
+    for (const team of sortedLivingTeams(current, config.controls, 'bot')) {
+      const movement = teamControlStrategy(team.teamNumber).chooseTeamMove(
+        current,
+        team.teamNumber,
+      );
+      if (movement === null) continue;
+      movementChoices.push({
+        teamId: team.teamNumber,
+        ...movement,
+      });
+    }
+
+    const resolved = resolveMovementChoices(current, movementChoices);
+    current = advanceMovement(
+      resolved.state,
+      pendingMovementAttribute,
+      resolved.teamMoves,
+    );
+    pendingMovementAttribute = null;
+  }
+
+  function applyRevival(
+    revivalActions: ReadonlyMap<TeamId, RevivalAction> | undefined,
+  ): void {
+    const choices = new Map<TeamId, RevivalAction>();
+
+    for (const team of sortedLivingTeams(current, config.controls, 'bot')) {
+      const revival = teamControlStrategy(team.teamNumber).chooseRevivalAction(
+        current,
+        team.teamNumber,
+      );
+      if (revival !== null) {
+        choices.set(team.teamNumber, revival);
+      }
+    }
+
+    for (const [teamId, action] of revivalActions ?? new Map()) {
+      choices.set(teamId, action);
+    }
+
+    current = advanceRevival(current, choices);
+  }
+
+  function teamControlStrategy(teamId: TeamId): TeamStrategy {
+    const control = controlFor(config.controls, teamId);
+    if (control.type !== 'bot') {
+      throw new Error(`Team ${teamId} is not bot-controlled.`);
+    }
+    return control.strategy;
+  }
+
+  function awaiting(request: HumanInputRequest): SessionStep {
+    pendingRequest = request;
+    return { status: 'awaiting', request, state: current };
+  }
+
+  return {
+    get state() {
+      return current;
+    },
+    step(humanInputs) {
+      if (isGameOver(current)) {
+        return { status: 'done', state: current };
+      }
+
+      if (pendingRequest !== null) {
+        switch (pendingRequest.phase) {
+          case 'battle':
+            if (
+              !hasCompleteInputs(
+                pendingRequest.humanTeams,
+                humanInputs?.battlePlays,
+              )
+            ) {
+              return {
+                status: 'awaiting',
+                request: pendingRequest,
+                state: current,
+              };
+            }
+            break;
+          case 'movement':
+            if (
+              !hasCompleteInputs(
+                pendingRequest.humanTeams,
+                humanInputs?.teamMoves,
+              )
+            ) {
+              return {
+                status: 'awaiting',
+                request: pendingRequest,
+                state: current,
+              };
+            }
+            break;
+          case 'revival':
+            if (humanInputs?.revivalActions === undefined) {
+              return {
+                status: 'awaiting',
+                request: pendingRequest,
+                state: current,
+              };
+            }
+            break;
+        }
+        pendingRequest = null;
+      }
+
+      while (true) {
+        if (isGameOver(current)) {
+          return { status: 'done', state: current };
+        }
+
+        switch (current.phase) {
+          case 'battle': {
+            const humanTeams = humanBattleTeams(current, config.controls);
+            if (!hasCompleteInputs(humanTeams, humanInputs?.battlePlays)) {
+              return awaiting({ phase: 'battle', humanTeams });
+            }
+            applyBattle(humanInputs?.battlePlays);
+            humanInputs = undefined;
+            continue;
+          }
+          case 'forbidden': {
+            const forbiddenDraw = drawFromDeck(current.deck, 2);
+            if (forbiddenDraw.drawn.length < 2) {
+              current = { ...current, phase: 'movement' };
+              continue;
+            }
+            current = advanceForbidden(
+              { ...current, deck: forbiddenDraw.remaining },
+              [
+                coerceToElementCard(forbiddenDraw.drawn[0] as Card),
+                coerceToElementCard(forbiddenDraw.drawn[1] as Card),
+              ],
+            );
+            continue;
+          }
+          case 'movement': {
+            const humanTeams = prepareMovement();
+            if (pendingMovementAttribute === null) {
+              continue;
+            }
+            if (!hasCompleteInputs(humanTeams, humanInputs?.teamMoves)) {
+              return awaiting({
+                phase: 'movement',
+                humanTeams,
+                movementAttribute: pendingMovementAttribute,
+              });
+            }
+            applyMovement(humanInputs?.teamMoves, humanTeams);
+            humanInputs = undefined;
+            continue;
+          }
+          case 'revival': {
+            const humanTeams = eligibleRevivalHumanTeams(
+              current,
+              config.controls,
+            );
+            if (
+              humanInputs?.revivalActions === undefined &&
+              humanTeams.length > 0
+            ) {
+              return awaiting({ phase: 'revival', humanTeams });
+            }
+            applyRevival(humanInputs?.revivalActions);
+            return { status: 'done', state: current };
+          }
+        }
+      }
+    },
+  };
+}

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -231,11 +231,14 @@ export function createSession(
       plays.push({ teamId, card: battle.card });
     }
 
-    current = {
-      ...resolveBattlePhase(current, plays, config.gameConfig ?? DEFAULT_CONFIG)
-        .state,
-      phase: 'forbidden',
-    };
+    const resolved = resolveBattlePhase(
+      current,
+      plays,
+      config.gameConfig ?? DEFAULT_CONFIG,
+    );
+    current = isGameOver(resolved.state)
+      ? resolved.state
+      : { ...resolved.state, phase: 'forbidden' };
   }
 
   function prepareMovement(): readonly TeamId[] {
@@ -309,7 +312,12 @@ export function createSession(
       });
     }
 
-    const resolved = resolveMovementChoices(current, movementChoices);
+    const resolved = resolveMovementChoices(
+      current,
+      movementChoices,
+      undefined,
+      { invalidExplicitChoice: 'skip' },
+    );
     current = advanceMovement(
       resolved.state,
       pendingMovementAttribute,

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -317,7 +317,7 @@ export function createSession(
       current,
       movementChoices,
       undefined,
-      { invalidExplicitChoice: 'skip' },
+      { skipInvalidExplicitChoiceTeamIds: new Set(humanTeams) },
     );
     current = advanceMovement(
       resolved.state,

--- a/packages/core/src/strategy/strategy.ts
+++ b/packages/core/src/strategy/strategy.ts
@@ -35,5 +35,4 @@ export type TeamStrategy = {
   ) => RevivalAction | null;
 };
 
-/** Returns the current team snapshot for a team id, if still on the board. */
 export { findTeam, isTeamAlive } from '../logic/phase-helpers.ts';

--- a/packages/core/src/strategy/strategy.ts
+++ b/packages/core/src/strategy/strategy.ts
@@ -1,7 +1,6 @@
 import type { BattlePlay } from '../logic/battle.ts';
 import type { RevivalAction, RoundState } from '../logic/round.ts';
 import type { MovementChoice } from '../logic/runner.ts';
-import { ELEMENT_AXIS, type TeamState } from '../types/grid.ts';
 import type { TeamId } from '../types/token.ts';
 
 type ExplicitStrategyMovementChoice = Omit<
@@ -36,25 +35,5 @@ export type TeamStrategy = {
   ) => RevivalAction | null;
 };
 
-function allTeams(state: RoundState): TeamState[] {
-  const teams: TeamState[] = [];
-  for (const x of ELEMENT_AXIS) {
-    for (const y of ELEMENT_AXIS) {
-      teams.push(...state.grid[x][y]);
-    }
-  }
-  return teams;
-}
-
 /** Returns the current team snapshot for a team id, if still on the board. */
-export function findTeam(
-  state: RoundState,
-  teamId: TeamId,
-): TeamState | undefined {
-  return allTeams(state).find((team) => team.teamNumber === teamId);
-}
-
-/** Returns true when the team still has at least one living player. */
-export function isTeamAlive(team: TeamState): boolean {
-  return team.players.some((player) => player.life > 0);
-}
+export { findTeam, isTeamAlive } from '../logic/phase-helpers.ts';


### PR DESCRIPTION
## Summary
- add a session manager that steps battle, forbidden, movement, and revival for mixed human/bot tables
- share movement draw and fallback resolution helpers between the round runner and the new session flow
- cover all-bot, mixed, all-human, and empty-hand fallback paths in session tests

## Testing
- pnpm run test
- pnpm -r typecheck
- pnpm run lint

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public session APIs added: a session-driven state machine for battle → movement → revival with step-based advancement and session/request types; movement-attribute and empty-hand priming occur before prompts.

* **Refactor**
  * Movement resolution and grid helpers centralized into shared logic; runner now routes movement-phase logs through the session flow and re-exports movement types; strategy helpers re-exported from shared logic.

* **Tests**
  * Extensive tests for bot/human flows, empty-hand fallbacks, awaiting prompts, invalid-move errors, and multi-round smoke runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->