### PR TITLE
feat(web): add game setup screen

### DIFF
--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it } from 'vitest';
+import { App } from './App.tsx';
+
+afterEach(cleanup);
+
+describe('App', () => {
+  it('routes to setup on first load and switches to the playing placeholder on submit', () => {
+    render(() => <App />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Dream Duels Setup' }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Start game' }));
+
+    expect(
+      screen.getByRole('heading', { name: 'Game session ready' }),
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Game grid — battle phase')).toBeTruthy();
+  });
+});

--- a/packages/web/src/App.test.tsx
+++ b/packages/web/src/App.test.tsx
@@ -16,6 +16,6 @@ describe('App', () => {
     expect(
       screen.getByRole('heading', { name: 'Game session ready' }),
     ).toBeTruthy();
-    expect(screen.getByLabelText('Game grid — battle phase')).toBeTruthy();
+    expect(screen.getByLabelText(/game grid .* phase/i)).toBeTruthy();
   });
 });

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -94,6 +94,9 @@ export function App() {
 
   function handleStart(values: SetupValues) {
     if (!isValidSetupValues(values)) {
+      // Defence-in-depth: SetupScreen guards this path via startBlocked(),
+      // but log an error so regressions are immediately diagnosable.
+      console.error('[App] handleStart received invalid setup values', values);
       return;
     }
 
@@ -144,7 +147,7 @@ export function App() {
 
                 <GameGrid
                   grid={activeState.grid}
-                  forbiddenCells={[...activeState.forbiddenCells]}
+                  forbiddenCells={activeState.forbiddenCells}
                   currentPhase={activeState.phase}
                 />
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -94,6 +94,7 @@ export function App() {
 
   function handleStart(values: SetupValues) {
     if (!isValidSetupValues(values)) {
+      console.warn('Rejected invalid setup values.', values);
       return;
     }
 
@@ -144,7 +145,7 @@ export function App() {
 
                 <GameGrid
                   grid={activeState.grid}
-                  forbiddenCells={[...activeState.forbiddenCells]}
+                  forbiddenCells={activeState.forbiddenCells}
                   currentPhase={activeState.phase}
                 />
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -7,9 +7,12 @@ import { createSignal, For, Match, Switch } from 'solid-js';
 import { GameGrid } from './components/Grid.tsx';
 import { SetupScreen, type SetupValues } from './screens/SetupScreen.tsx';
 import {
+  cloneConfig,
   deriveTeamSummaries,
   MAX_STARTABLE_PLAYER_COUNT,
   MIN_PLAYER_COUNT,
+  normalizeSeed,
+  normalizeSetupConfig,
 } from './screens/setup-screen-model.ts';
 
 type PlayingState = {
@@ -27,13 +30,30 @@ function isNonNegativeInteger(value: number): boolean {
   return Number.isInteger(value) && value >= 0;
 }
 
+function isSameConfig(
+  left: SetupValues['config'],
+  right: SetupValues['config'],
+) {
+  return (
+    left.cardCopies === right.cardCopies &&
+    left.deckExtractFactor === right.deckExtractFactor &&
+    left.randomCardsDealt === right.randomCardsDealt &&
+    left.battleTimeLimitMin === right.battleTimeLimitMin &&
+    left.damageOverflowFactor === right.damageOverflowFactor
+  );
+}
+
 function isValidSetupValues(values: SetupValues): boolean {
+  const normalizedConfig = normalizeSetupConfig(
+    cloneConfig(values.config),
+    values.playerCount,
+  );
   if (
     !Number.isInteger(values.playerCount) ||
     values.playerCount < MIN_PLAYER_COUNT ||
     values.playerCount > MAX_STARTABLE_PLAYER_COUNT ||
-    !Number.isFinite(values.seed) ||
-    !Number.isInteger(values.seed)
+    !Number.isInteger(values.seed) ||
+    values.seed !== normalizeSeed(values.seed, values.seed)
   ) {
     return false;
   }
@@ -43,7 +63,8 @@ function isValidSetupValues(values: SetupValues): boolean {
     !isPositiveInteger(values.config.deckExtractFactor) ||
     !isNonNegativeInteger(values.config.randomCardsDealt) ||
     !isPositiveInteger(values.config.battleTimeLimitMin) ||
-    !isPositiveInteger(values.config.damageOverflowFactor)
+    !isPositiveInteger(values.config.damageOverflowFactor) ||
+    !isSameConfig(values.config, normalizedConfig)
   ) {
     return false;
   }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -6,7 +6,11 @@ import {
 import { createSignal, For, Match, Switch } from 'solid-js';
 import { GameGrid } from './components/Grid.tsx';
 import { SetupScreen, type SetupValues } from './screens/SetupScreen.tsx';
-import { MAX_STARTABLE_PLAYER_COUNT } from './screens/setup-screen-model.ts';
+import {
+  deriveTeamSummaries,
+  MAX_STARTABLE_PLAYER_COUNT,
+  MIN_PLAYER_COUNT,
+} from './screens/setup-screen-model.ts';
 
 type PlayingState = {
   readonly mode: 'playing';
@@ -15,13 +19,60 @@ type PlayingState = {
   readonly setup: SetupValues;
 };
 
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value >= 1;
+}
+
+function isNonNegativeInteger(value: number): boolean {
+  return Number.isInteger(value) && value >= 0;
+}
+
+function isValidSetupValues(values: SetupValues): boolean {
+  if (
+    !Number.isInteger(values.playerCount) ||
+    values.playerCount < MIN_PLAYER_COUNT ||
+    values.playerCount > MAX_STARTABLE_PLAYER_COUNT ||
+    !Number.isFinite(values.seed) ||
+    !Number.isInteger(values.seed)
+  ) {
+    return false;
+  }
+
+  if (
+    !isPositiveInteger(values.config.cardCopies) ||
+    !isPositiveInteger(values.config.deckExtractFactor) ||
+    !isNonNegativeInteger(values.config.randomCardsDealt) ||
+    !isPositiveInteger(values.config.battleTimeLimitMin) ||
+    !isPositiveInteger(values.config.damageOverflowFactor)
+  ) {
+    return false;
+  }
+
+  if (!(values.controls instanceof Map)) {
+    return false;
+  }
+
+  const expectedTeams = deriveTeamSummaries(values.playerCount);
+  if (values.controls.size !== expectedTeams.length) {
+    return false;
+  }
+
+  return expectedTeams.every((team) => {
+    const control = values.controls.get(team.teamId);
+    return (
+      control?.type === 'human' ||
+      (control?.type === 'bot' && control.strategy !== undefined)
+    );
+  });
+}
+
 export function App() {
   const [view, setView] = createSignal<{ mode: 'setup' } | PlayingState>({
     mode: 'setup',
   });
 
   function handleStart(values: SetupValues) {
-    if (values.playerCount > MAX_STARTABLE_PLAYER_COUNT) {
+    if (!isValidSetupValues(values)) {
       return;
     }
 

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,39 +1,101 @@
-import type { Card, Grid } from '@kurone-kito/oneiron-core';
-import { createEmptyGrid } from '@kurone-kito/oneiron-core';
+import {
+  createSession,
+  type RoundState,
+  setupGame,
+} from '@kurone-kito/oneiron-core';
+import { createSignal, For, Match, Switch } from 'solid-js';
 import { GameGrid } from './components/Grid.tsx';
-import { Hand } from './components/Hand.tsx';
+import { SetupScreen, type SetupValues } from './screens/SetupScreen.tsx';
+import { MAX_STARTABLE_PLAYER_COUNT } from './screens/setup-screen-model.ts';
 
-const demoCards: Card[] = [
-  { kind: 'element', element: 'fire', value: 7 },
-  { kind: 'element', element: 'water', value: 3 },
-  { kind: 'joker' },
-];
-
-const demoGrid: Grid = (() => {
-  const g = createEmptyGrid();
-  return {
-    ...g,
-    fire: {
-      ...g.fire,
-      water: [
-        {
-          teamNumber: 1,
-          position: { x: 'fire', y: 'water' },
-          facing: 'north',
-          cards: [],
-          players: [{ life: 3 }, { life: 4 }],
-        },
-      ],
-    },
-  } as Grid;
-})();
+type PlayingState = {
+  readonly mode: 'playing';
+  readonly initialState: RoundState;
+  readonly session: ReturnType<typeof createSession>;
+  readonly setup: SetupValues;
+};
 
 export function App() {
+  const [view, setView] = createSignal<{ mode: 'setup' } | PlayingState>({
+    mode: 'setup',
+  });
+
+  function handleStart(values: SetupValues) {
+    if (values.playerCount > MAX_STARTABLE_PLAYER_COUNT) {
+      return;
+    }
+
+    const initialState = setupGame(
+      { playerCount: values.playerCount, seed: values.seed },
+      values.config,
+    );
+    const session = createSession(initialState, {
+      controls: values.controls,
+      gameConfig: values.config,
+    });
+
+    setView({
+      mode: 'playing',
+      initialState,
+      session,
+      setup: values,
+    });
+  }
+
   return (
     <main>
-      <h1>⚔️ Dream Duels: The Battle for Oneiron</h1>
-      <GameGrid grid={demoGrid} forbiddenCells={[]} currentPhase="battle" />
-      <Hand cards={demoCards} label="Demo Hand (face up)" faceUp={true} />
+      <Switch>
+        <Match when={view().mode === 'setup'}>
+          <SetupScreen onStart={handleStart} />
+        </Match>
+        <Match when={view().mode === 'playing'}>
+          {(() => {
+            const playing = view() as PlayingState;
+            const activeState = playing.session.state;
+            const controlSummary = Array.from(playing.setup.controls.entries())
+              .sort(([left], [right]) => Number(left) - Number(right))
+              .map(([teamId, control]) => ({
+                teamId,
+                control: control.type,
+              }));
+
+            return (
+              <section aria-label="Playing placeholder">
+                <header>
+                  <p>Wave-6 placeholder</p>
+                  <h1>Game session ready</h1>
+                  <p>
+                    Round {activeState.round} begins in the {activeState.phase}{' '}
+                    phase. Full interactive controls land in #126.
+                  </p>
+                </header>
+
+                <GameGrid
+                  grid={activeState.grid}
+                  forbiddenCells={[...activeState.forbiddenCells]}
+                  currentPhase={activeState.phase}
+                />
+
+                <section aria-label="Session summary">
+                  <h2>Session summary</h2>
+                  <p>Seed: {playing.setup.seed}</p>
+                  <p>Deck size: {activeState.deck?.length ?? 0}</p>
+                  <p>Initial phase: {playing.initialState.phase}</p>
+                  <ul aria-label="Configured controls">
+                    <For each={controlSummary}>
+                      {(entry) => (
+                        <li>
+                          Team {entry.teamId}: {entry.control}
+                        </li>
+                      )}
+                    </For>
+                  </ul>
+                </section>
+              </section>
+            );
+          })()}
+        </Match>
+      </Switch>
     </main>
   );
 }

--- a/packages/web/src/components/Grid.tsx
+++ b/packages/web/src/components/Grid.tsx
@@ -16,11 +16,14 @@ const FACING_ARROW: Record<string, string> = {
 
 type Props = {
   grid: Grid;
-  forbiddenCells: GridCoord[];
+  forbiddenCells: readonly GridCoord[];
   currentPhase: RoundPhase;
 };
 
-function isForbidden(coord: GridCoord, forbidden: GridCoord[]): boolean {
+function isForbidden(
+  coord: GridCoord,
+  forbidden: readonly GridCoord[],
+): boolean {
   return forbidden.some((c) => c.x === coord.x && c.y === coord.y);
 }
 

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -80,10 +80,10 @@ describe('SetupScreen', () => {
     const onStart = vi.fn();
     render(() => <SetupScreen onStart={onStart} />);
 
-    fireEvent.change(screen.getByLabelText('Control for Team 1'), {
+    fireEvent.change(screen.getByLabelText('Team 1 (pair)'), {
       target: { value: 'bot' },
     });
-    fireEvent.change(screen.getByLabelText('Control for Team 2'), {
+    fireEvent.change(screen.getByLabelText('Team 2 (pair)'), {
       target: { value: 'human' },
     });
     fireEvent.input(screen.getByLabelText('Card copies (A)'), {
@@ -120,7 +120,7 @@ describe('SetupScreen', () => {
       target: { value: '18', valueAsNumber: 18 },
     });
     fireEvent.input(screen.getByLabelText('Seed'), {
-      target: { value: '1e309', valueAsNumber: Number.POSITIVE_INFINITY },
+      target: { value: '1e309' },
     });
     fireEvent.input(screen.getByLabelText('Card copies (A)'), {
       target: { value: '10000', valueAsNumber: 10_000 },

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -1,0 +1,128 @@
+import { DEFAULT_CONFIG } from '@kurone-kito/oneiron-core';
+import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SetupScreen } from './SetupScreen.tsx';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('SetupScreen', () => {
+  it('renders without errors', () => {
+    render(() => <SetupScreen onStart={() => undefined} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Dream Duels Setup' }),
+    ).toBeTruthy();
+    expect(screen.getByLabelText('Player count')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Start game' })).toBeTruthy();
+  });
+
+  it('updates the team list when player count changes', () => {
+    render(() => <SetupScreen onStart={() => undefined} />);
+
+    const playerCount = screen.getByLabelText('Player count');
+    fireEvent.input(playerCount, { target: { value: '2' } });
+    expect(screen.getByText('Team 1 (pair)')).toBeTruthy();
+    expect(screen.queryByText('Team 2 (pair)')).toBeNull();
+
+    fireEvent.input(playerCount, { target: { value: '6' } });
+    expect(screen.getByText('Team 3 (pair)')).toBeTruthy();
+
+    fireEvent.input(playerCount, { target: { value: '9' } });
+    expect(screen.getByText('Team 5 (solo)')).toBeTruthy();
+  });
+
+  it('randomises the seed to a non-zero number', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+    render(() => <SetupScreen onStart={() => undefined} />);
+
+    const seedInput = screen.getByLabelText('Seed') as HTMLInputElement;
+    fireEvent.input(seedInput, { target: { value: '0' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Randomise seed' }));
+
+    expect(Number(seedInput.value)).toBe(4242);
+  });
+
+  it('fires start game with constructed setup values', () => {
+    const onStart = vi.fn();
+    render(() => <SetupScreen onStart={onStart} />);
+
+    fireEvent.input(screen.getByLabelText('Player count'), {
+      target: { value: '4' },
+    });
+    fireEvent.input(screen.getByLabelText('Seed'), { target: { value: '77' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Start game' }));
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    const [values] = onStart.mock.calls[0] as [unknown];
+    const setup = values as {
+      playerCount: number;
+      seed: number;
+      config: typeof DEFAULT_CONFIG;
+      controls: Map<number, { type: 'human' | 'bot' }>;
+    };
+
+    expect(setup.playerCount).toBe(4);
+    expect(setup.seed).toBe(77);
+    expect(setup.config).toEqual(DEFAULT_CONFIG);
+    expect(setup.controls).toBeInstanceOf(Map);
+    expect(setup.controls.get(1)?.type).toBe('human');
+    expect(setup.controls.get(2)?.type).toBe('bot');
+  });
+
+  it('sanitizes config overrides and includes custom team controls', () => {
+    const onStart = vi.fn();
+    render(() => <SetupScreen onStart={onStart} />);
+
+    fireEvent.change(screen.getByLabelText('Control for Team 1'), {
+      target: { value: 'bot' },
+    });
+    fireEvent.change(screen.getByLabelText('Control for Team 2'), {
+      target: { value: 'human' },
+    });
+    fireEvent.input(screen.getByLabelText('Card copies (A)'), {
+      target: { value: '0' },
+    });
+    fireEvent.input(screen.getByLabelText('Random cards dealt (C)'), {
+      target: { value: '-5' },
+    });
+    fireEvent.input(screen.getByLabelText('Damage overflow factor (E)'), {
+      target: { value: '3' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Start game' }));
+
+    const [values] = onStart.mock.calls[0] as [unknown];
+    const setup = values as {
+      config: typeof DEFAULT_CONFIG;
+      controls: Map<number, { type: 'human' | 'bot' }>;
+    };
+
+    expect(setup.config.cardCopies).toBe(1);
+    expect(setup.config.randomCardsDealt).toBe(0);
+    expect(setup.config.damageOverflowFactor).toBe(3);
+    expect(setup.controls.get(1)?.type).toBe('bot');
+    expect(setup.controls.get(2)?.type).toBe('human');
+  });
+
+  it('keeps the 2..20 input but blocks start above the engine team limit', () => {
+    render(() => <SetupScreen onStart={() => undefined} />);
+
+    fireEvent.input(screen.getByLabelText('Player count'), {
+      target: { value: '20' },
+    });
+
+    expect(
+      screen.getByText(
+        'Current engine start is capped at 18 players because the 3x3 grid can host at most 9 teams.',
+      ),
+    ).toBeTruthy();
+    expect(
+      (screen.getByRole('button', { name: 'Start game' }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    expect(screen.getByText('Team 10 (pair)')).toBeTruthy();
+  });
+});

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -2,6 +2,10 @@ import { DEFAULT_CONFIG } from '@kurone-kito/oneiron-core';
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SetupScreen } from './SetupScreen.tsx';
+import {
+  deriveSetupConfigLimits,
+  MAX_CARD_COPIES,
+} from './setup-screen-model.ts';
 
 afterEach(() => {
   cleanup();
@@ -53,7 +57,7 @@ describe('SetupScreen', () => {
       target: { value: '4' },
     });
     fireEvent.input(screen.getByLabelText('Seed'), { target: { value: '77' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Start game' }));
+    fireEvent.submit(screen.getByRole('button', { name: 'Start game' }).form);
 
     expect(onStart).toHaveBeenCalledTimes(1);
     const [values] = onStart.mock.calls[0] as [unknown];
@@ -92,7 +96,7 @@ describe('SetupScreen', () => {
       target: { value: '3' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Start game' }));
+    fireEvent.submit(screen.getByRole('button', { name: 'Start game' }).form);
 
     const [values] = onStart.mock.calls[0] as [unknown];
     const setup = values as {
@@ -105,6 +109,42 @@ describe('SetupScreen', () => {
     expect(setup.config.damageOverflowFactor).toBe(3);
     expect(setup.controls.get(1)?.type).toBe('bot');
     expect(setup.controls.get(2)?.type).toBe('human');
+  });
+
+  it('normalizes non-finite seeds and oversized config overrides before submit', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+    const onStart = vi.fn();
+    render(() => <SetupScreen onStart={onStart} />);
+
+    fireEvent.input(screen.getByLabelText('Player count'), {
+      target: { value: '18', valueAsNumber: 18 },
+    });
+    fireEvent.input(screen.getByLabelText('Seed'), {
+      target: { value: '1e309', valueAsNumber: Number.POSITIVE_INFINITY },
+    });
+    fireEvent.input(screen.getByLabelText('Card copies (A)'), {
+      target: { value: '10000', valueAsNumber: 10_000 },
+    });
+    fireEvent.input(screen.getByLabelText('Deck extract factor (B)'), {
+      target: { value: '10000', valueAsNumber: 10_000 },
+    });
+    fireEvent.input(screen.getByLabelText('Random cards dealt (C)'), {
+      target: { value: '10000', valueAsNumber: 10_000 },
+    });
+
+    fireEvent.submit(screen.getByRole('button', { name: 'Start game' }).form);
+
+    const [values] = onStart.mock.calls[0] as [unknown];
+    const setup = values as {
+      seed: number;
+      config: typeof DEFAULT_CONFIG;
+    };
+    const limits = deriveSetupConfigLimits(18, setup.config);
+
+    expect(setup.seed).toBe(4242);
+    expect(setup.config.cardCopies).toBe(MAX_CARD_COPIES);
+    expect(setup.config.deckExtractFactor).toBe(limits.deckExtractFactor);
+    expect(setup.config.randomCardsDealt).toBe(limits.randomCardsDealt);
   });
 
   it('keeps the 2..20 input but blocks start above the engine team limit', () => {

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -49,6 +49,22 @@ describe('SetupScreen', () => {
     expect(Number(seedInput.value)).toBe(4242);
   });
 
+  it('preserves intermediate seed drafts until blur and then normalizes them', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(4242);
+    render(() => <SetupScreen onStart={() => undefined} />);
+
+    const seedInput = screen.getByLabelText('Seed') as HTMLInputElement;
+    expect(seedInput.type).toBe('text');
+
+    fireEvent.input(seedInput, { target: { value: '-' } });
+
+    expect(seedInput.value).toBe('-');
+
+    fireEvent.blur(seedInput);
+
+    expect(seedInput.value).toBe('4242');
+  });
+
   it('fires start game with constructed setup values', () => {
     const onStart = vi.fn();
     render(() => <SetupScreen onStart={onStart} />);

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -108,7 +108,8 @@ describe('SetupScreen', () => {
   });
 
   it('keeps the 2..20 input but blocks start above the engine team limit', () => {
-    render(() => <SetupScreen onStart={() => undefined} />);
+    const onStart = vi.fn();
+    render(() => <SetupScreen onStart={onStart} />);
 
     fireEvent.input(screen.getByLabelText('Player count'), {
       target: { value: '20' },
@@ -124,5 +125,7 @@ describe('SetupScreen', () => {
         .disabled,
     ).toBe(true);
     expect(screen.getByText('Team 10 (pair)')).toBeTruthy();
+    fireEvent.submit(screen.getByRole('button', { name: 'Start game' }).form);
+    expect(onStart).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -52,8 +52,10 @@ function updateInteger(
 }
 
 export function SetupScreen(props: Props) {
+  const initialSeed = createRandomSeed();
   const [playerCount, setPlayerCount] = createSignal(6);
-  const [seed, setSeed] = createSignal(createRandomSeed());
+  const [seed, setSeed] = createSignal(initialSeed);
+  const [seedText, setSeedText] = createSignal(String(initialSeed));
   const [config, setConfig] = createStore<ConfigDraft>(
     cloneConfig(DEFAULT_CONFIG),
   );
@@ -78,10 +80,30 @@ export function SetupScreen(props: Props) {
   });
 
   createEffect(() => {
+    const count = playerCount();
     setConfig(
-      reconcile(normalizeSetupConfig(cloneConfig(config), playerCount())),
+      reconcile(
+        normalizeSetupConfig(
+          untrack(() => cloneConfig(config)),
+          count,
+        ),
+      ),
     );
   });
+
+  function parseSeedText(value: string): number {
+    if (value.trim() === '') {
+      return Number.NaN;
+    }
+    return Number(value);
+  }
+
+  function commitSeedText(): number {
+    const normalizedSeed = normalizeSeed(parseSeedText(seedText()), seed());
+    setSeed(normalizedSeed);
+    setSeedText(String(normalizedSeed));
+    return normalizedSeed;
+  }
 
   function updateConfigField<Key extends keyof ConfigDraft>(
     key: Key,
@@ -104,7 +126,7 @@ export function SetupScreen(props: Props) {
     if (startBlocked()) {
       return;
     }
-    const normalizedSeed = normalizeSeed(seed(), seed());
+    const normalizedSeed = commitSeedText();
     const normalizedConfig = normalizeSetupConfig(
       cloneConfig(config),
       playerCount(),
@@ -164,16 +186,17 @@ export function SetupScreen(props: Props) {
               min={MIN_SETUP_SEED}
               max={MAX_SETUP_SEED}
               step="1"
-              value={seed()}
-              onInput={(event) =>
-                setSeed(
-                  normalizeSeed(event.currentTarget.valueAsNumber, seed()),
-                )
-              }
+              value={seedText()}
+              onInput={(event) => setSeedText(event.currentTarget.value)}
+              onBlur={commitSeedText}
             />
             <button
               type="button"
-              onClick={() => setSeed(createRandomSeed())}
+              onClick={() => {
+                const nextSeed = createRandomSeed();
+                setSeed(nextSeed);
+                setSeedText(String(nextSeed));
+              }}
               aria-label="Randomise seed"
             >
               Randomise seed
@@ -192,7 +215,6 @@ export function SetupScreen(props: Props) {
                   </label>
                   <select
                     id={`team-control-${team.teamId}`}
-                    aria-label={`Control for Team ${team.teamId}`}
                     value={controlSelections[team.teamId] ?? 'bot'}
                     onChange={(event) =>
                       setControlSelections(
@@ -271,7 +293,6 @@ export function SetupScreen(props: Props) {
             id="config-d"
             type="number"
             min="1"
-            max={configLimits().battleTimeLimitMin}
             step="1"
             value={config.battleTimeLimitMin}
             onInput={(event) =>
@@ -287,7 +308,6 @@ export function SetupScreen(props: Props) {
             id="config-e"
             type="number"
             min="1"
-            max={configLimits().damageOverflowFactor}
             step="1"
             value={config.damageOverflowFactor}
             onInput={(event) =>

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -15,10 +15,15 @@ import {
   clampPlayerCount,
   cloneConfig,
   createRandomSeed,
+  deriveSetupConfigLimits,
   deriveTeamSummaries,
   MAX_PLAYER_COUNT,
+  MAX_SETUP_SEED,
   MAX_STARTABLE_PLAYER_COUNT,
   MIN_PLAYER_COUNT,
+  MIN_SETUP_SEED,
+  normalizeSeed,
+  normalizeSetupConfig,
   type SetupValues,
 } from './setup-screen-model.ts';
 
@@ -43,7 +48,7 @@ function updateInteger(
   fallback: number,
   normalize: (value: number) => number = Math.trunc,
 ): number {
-  return Number.isNaN(rawValue) ? fallback : normalize(rawValue);
+  return Number.isFinite(rawValue) ? normalize(rawValue) : fallback;
 }
 
 export function SetupScreen(props: Props) {
@@ -57,6 +62,9 @@ export function SetupScreen(props: Props) {
   >({});
 
   const teamSummaries = createMemo(() => deriveTeamSummaries(playerCount()));
+  const configLimits = createMemo(() =>
+    deriveSetupConfigLimits(playerCount(), config),
+  );
   const startBlocked = createMemo(
     () => playerCount() > MAX_STARTABLE_PLAYER_COUNT,
   );
@@ -69,17 +77,26 @@ export function SetupScreen(props: Props) {
     );
   });
 
+  createEffect(() => {
+    setConfig(
+      reconcile(normalizeSetupConfig(cloneConfig(config), playerCount())),
+    );
+  });
+
   function updateConfigField<Key extends keyof ConfigDraft>(
     key: Key,
     rawValue: number,
   ) {
-    const minimum = CONFIG_FIELD_MINIMUMS[key];
-    setConfig(
-      key,
-      updateInteger(rawValue, config[key], (value) =>
-        Math.max(minimum, Math.trunc(value)),
-      ),
+    const nextConfig = normalizeSetupConfig(
+      {
+        ...cloneConfig(config),
+        [key]: updateInteger(rawValue, config[key], (value) =>
+          Math.max(CONFIG_FIELD_MINIMUMS[key], Math.trunc(value)),
+        ),
+      },
+      playerCount(),
     );
+    setConfig(reconcile(nextConfig));
   }
 
   function handleSubmit(event: SubmitEvent) {
@@ -87,11 +104,20 @@ export function SetupScreen(props: Props) {
     if (startBlocked()) {
       return;
     }
+    const normalizedSeed = normalizeSeed(seed(), seed());
+    const normalizedConfig = normalizeSetupConfig(
+      cloneConfig(config),
+      playerCount(),
+    );
     props.onStart({
       playerCount: playerCount(),
-      seed: seed(),
-      config: cloneConfig(config),
-      controls: buildControlsMap(teamSummaries(), controlSelections, seed()),
+      seed: normalizedSeed,
+      config: normalizedConfig,
+      controls: buildControlsMap(
+        teamSummaries(),
+        controlSelections,
+        normalizedSeed,
+      ),
     });
   }
 
@@ -135,11 +161,13 @@ export function SetupScreen(props: Props) {
             <input
               id="seed"
               type="number"
+              min={MIN_SETUP_SEED}
+              max={MAX_SETUP_SEED}
               step="1"
               value={seed()}
               onInput={(event) =>
                 setSeed(
-                  updateInteger(event.currentTarget.valueAsNumber, seed()),
+                  normalizeSeed(event.currentTarget.valueAsNumber, seed()),
                 )
               }
             />
@@ -198,6 +226,7 @@ export function SetupScreen(props: Props) {
             id="config-a"
             type="number"
             min="1"
+            max={configLimits().cardCopies}
             step="1"
             value={config.cardCopies}
             onInput={(event) =>
@@ -210,6 +239,7 @@ export function SetupScreen(props: Props) {
             id="config-b"
             type="number"
             min="1"
+            max={configLimits().deckExtractFactor}
             step="1"
             value={config.deckExtractFactor}
             onInput={(event) =>
@@ -225,6 +255,7 @@ export function SetupScreen(props: Props) {
             id="config-c"
             type="number"
             min="0"
+            max={configLimits().randomCardsDealt}
             step="1"
             value={config.randomCardsDealt}
             onInput={(event) =>
@@ -240,6 +271,7 @@ export function SetupScreen(props: Props) {
             id="config-d"
             type="number"
             min="1"
+            max={configLimits().battleTimeLimitMin}
             step="1"
             value={config.battleTimeLimitMin}
             onInput={(event) =>
@@ -255,6 +287,7 @@ export function SetupScreen(props: Props) {
             id="config-e"
             type="number"
             min="1"
+            max={configLimits().damageOverflowFactor}
             step="1"
             value={config.damageOverflowFactor}
             onInput={(event) =>

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -16,7 +16,9 @@ import {
   cloneConfig,
   createRandomSeed,
   deriveTeamSummaries,
+  MAX_PLAYER_COUNT,
   MAX_STARTABLE_PLAYER_COUNT,
+  MIN_PLAYER_COUNT,
   type SetupValues,
 } from './setup-screen-model.ts';
 
@@ -82,6 +84,9 @@ export function SetupScreen(props: Props) {
 
   function handleSubmit(event: SubmitEvent) {
     event.preventDefault();
+    if (startBlocked()) {
+      return;
+    }
     props.onStart({
       playerCount: playerCount(),
       seed: seed(),
@@ -109,8 +114,8 @@ export function SetupScreen(props: Props) {
           <input
             id="player-count"
             type="number"
-            min="2"
-            max="20"
+            min={MIN_PLAYER_COUNT}
+            max={MAX_PLAYER_COUNT}
             step="1"
             value={playerCount()}
             onInput={(event) =>

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -18,10 +18,8 @@ import {
   deriveSetupConfigLimits,
   deriveTeamSummaries,
   MAX_PLAYER_COUNT,
-  MAX_SETUP_SEED,
   MAX_STARTABLE_PLAYER_COUNT,
   MIN_PLAYER_COUNT,
-  MIN_SETUP_SEED,
   normalizeSeed,
   normalizeSetupConfig,
   type SetupValues,
@@ -95,6 +93,7 @@ export function SetupScreen(props: Props) {
     if (value.trim() === '') {
       return Number.NaN;
     }
+    // `Number(...)` intentionally accepts signed and scientific-notation drafts.
     return Number(value);
   }
 
@@ -182,10 +181,8 @@ export function SetupScreen(props: Props) {
           <div>
             <input
               id="seed"
-              type="number"
-              min={MIN_SETUP_SEED}
-              max={MAX_SETUP_SEED}
-              step="1"
+              type="text"
+              inputMode="numeric"
               value={seedText()}
               onInput={(event) => setSeedText(event.currentTarget.value)}
               onBlur={commitSeedText}

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -1,0 +1,272 @@
+import { DEFAULT_CONFIG, type GameConfig } from '@kurone-kito/oneiron-core';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Show,
+  untrack,
+} from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+import {
+  buildControlSelections,
+  buildControlsMap,
+  type ControlMode,
+  clampPlayerCount,
+  cloneConfig,
+  createRandomSeed,
+  deriveTeamSummaries,
+  MAX_STARTABLE_PLAYER_COUNT,
+  type SetupValues,
+} from './setup-screen-model.ts';
+
+type Props = {
+  onStart: (values: SetupValues) => void;
+};
+
+type ConfigDraft = {
+  -readonly [Key in keyof GameConfig]: GameConfig[Key];
+};
+
+const CONFIG_FIELD_MINIMUMS: Readonly<Record<keyof ConfigDraft, number>> = {
+  cardCopies: 1,
+  deckExtractFactor: 1,
+  randomCardsDealt: 0,
+  battleTimeLimitMin: 1,
+  damageOverflowFactor: 1,
+};
+
+function updateInteger(
+  rawValue: number,
+  fallback: number,
+  normalize: (value: number) => number = Math.trunc,
+): number {
+  return Number.isNaN(rawValue) ? fallback : normalize(rawValue);
+}
+
+export function SetupScreen(props: Props) {
+  const [playerCount, setPlayerCount] = createSignal(6);
+  const [seed, setSeed] = createSignal(createRandomSeed());
+  const [config, setConfig] = createStore<ConfigDraft>(
+    cloneConfig(DEFAULT_CONFIG),
+  );
+  const [controlSelections, setControlSelections] = createStore<
+    Record<number, ControlMode>
+  >({});
+
+  const teamSummaries = createMemo(() => deriveTeamSummaries(playerCount()));
+  const startBlocked = createMemo(
+    () => playerCount() > MAX_STARTABLE_PLAYER_COUNT,
+  );
+
+  createEffect(() => {
+    const nextTeams = teamSummaries();
+    const previousSelections = untrack(() => ({ ...controlSelections }));
+    setControlSelections(
+      reconcile(buildControlSelections(nextTeams, previousSelections)),
+    );
+  });
+
+  function updateConfigField<Key extends keyof ConfigDraft>(
+    key: Key,
+    rawValue: number,
+  ) {
+    const minimum = CONFIG_FIELD_MINIMUMS[key];
+    setConfig(
+      key,
+      updateInteger(rawValue, config[key], (value) =>
+        Math.max(minimum, Math.trunc(value)),
+      ),
+    );
+  }
+
+  function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    props.onStart({
+      playerCount: playerCount(),
+      seed: seed(),
+      config: cloneConfig(config),
+      controls: buildControlsMap(teamSummaries(), controlSelections, seed()),
+    });
+  }
+
+  return (
+    <section aria-label="Game setup">
+      <header>
+        <p>Wave-6 setup</p>
+        <h1>Dream Duels Setup</h1>
+        <p>
+          Configure the roster, seed, and A-E values before handing the table to
+          the session manager.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit}>
+        <fieldset>
+          <legend>Match setup</legend>
+
+          <label for="player-count">Player count</label>
+          <input
+            id="player-count"
+            type="number"
+            min="2"
+            max="20"
+            step="1"
+            value={playerCount()}
+            onInput={(event) =>
+              setPlayerCount(
+                clampPlayerCount(
+                  updateInteger(
+                    event.currentTarget.valueAsNumber,
+                    playerCount(),
+                  ),
+                ),
+              )
+            }
+          />
+
+          <label for="seed">Seed</label>
+          <div>
+            <input
+              id="seed"
+              type="number"
+              step="1"
+              value={seed()}
+              onInput={(event) =>
+                setSeed(
+                  updateInteger(event.currentTarget.valueAsNumber, seed()),
+                )
+              }
+            />
+            <button
+              type="button"
+              onClick={() => setSeed(createRandomSeed())}
+              aria-label="Randomise seed"
+            >
+              Randomise seed
+            </button>
+          </div>
+        </fieldset>
+
+        <fieldset>
+          <legend>Per-team control</legend>
+          <ul aria-label="Derived teams">
+            <For each={teamSummaries()}>
+              {(team) => (
+                <li>
+                  <label for={`team-control-${team.teamId}`}>
+                    {team.label}
+                  </label>
+                  <select
+                    id={`team-control-${team.teamId}`}
+                    aria-label={`Control for Team ${team.teamId}`}
+                    value={controlSelections[team.teamId] ?? 'bot'}
+                    onChange={(event) =>
+                      setControlSelections(
+                        team.teamId,
+                        event.currentTarget.value as ControlMode,
+                      )
+                    }
+                  >
+                    <option value="human">Human</option>
+                    <option value="bot">Bot</option>
+                  </select>
+                  <span>{team.memberCount} player(s)</span>
+                </li>
+              )}
+            </For>
+          </ul>
+        </fieldset>
+
+        <Show when={startBlocked()}>
+          <p role="status">
+            Current engine start is capped at 18 players because the 3x3 grid
+            can host at most 9 teams.
+          </p>
+        </Show>
+
+        <details>
+          <summary>A-E values</summary>
+
+          <label for="config-a">Card copies (A)</label>
+          <input
+            id="config-a"
+            type="number"
+            min="1"
+            step="1"
+            value={config.cardCopies}
+            onInput={(event) =>
+              updateConfigField('cardCopies', event.currentTarget.valueAsNumber)
+            }
+          />
+
+          <label for="config-b">Deck extract factor (B)</label>
+          <input
+            id="config-b"
+            type="number"
+            min="1"
+            step="1"
+            value={config.deckExtractFactor}
+            onInput={(event) =>
+              updateConfigField(
+                'deckExtractFactor',
+                event.currentTarget.valueAsNumber,
+              )
+            }
+          />
+
+          <label for="config-c">Random cards dealt (C)</label>
+          <input
+            id="config-c"
+            type="number"
+            min="0"
+            step="1"
+            value={config.randomCardsDealt}
+            onInput={(event) =>
+              updateConfigField(
+                'randomCardsDealt',
+                event.currentTarget.valueAsNumber,
+              )
+            }
+          />
+
+          <label for="config-d">Battle time limit minutes (D)</label>
+          <input
+            id="config-d"
+            type="number"
+            min="1"
+            step="1"
+            value={config.battleTimeLimitMin}
+            onInput={(event) =>
+              updateConfigField(
+                'battleTimeLimitMin',
+                event.currentTarget.valueAsNumber,
+              )
+            }
+          />
+
+          <label for="config-e">Damage overflow factor (E)</label>
+          <input
+            id="config-e"
+            type="number"
+            min="1"
+            step="1"
+            value={config.damageOverflowFactor}
+            onInput={(event) =>
+              updateConfigField(
+                'damageOverflowFactor',
+                event.currentTarget.valueAsNumber,
+              )
+            }
+          />
+        </details>
+
+        <button type="submit" disabled={startBlocked()}>
+          Start game
+        </button>
+      </form>
+    </section>
+  );
+}
+
+export type { SetupValues } from './setup-screen-model.ts';

--- a/packages/web/src/screens/setup-screen-model.test.ts
+++ b/packages/web/src/screens/setup-screen-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   clampPlayerCount,
+  createRandomSeed,
   deriveSetupConfigLimits,
   MAX_CARD_COPIES,
   MAX_SETUP_SEED,
@@ -27,6 +28,13 @@ describe('normalizeSeed', () => {
     expect(normalizeSeed(Number.NEGATIVE_INFINITY, 7)).toBe(7);
     expect(normalizeSeed(2 ** 40)).toBe(MAX_SETUP_SEED);
     expect(normalizeSeed(-(2 ** 40))).toBe(MIN_SETUP_SEED);
+  });
+});
+
+describe('createRandomSeed', () => {
+  it('maps zero and full-cycle timestamps to 1', () => {
+    expect(createRandomSeed(0)).toBe(1);
+    expect(createRandomSeed(2 ** 31)).toBe(1);
   });
 });
 

--- a/packages/web/src/screens/setup-screen-model.test.ts
+++ b/packages/web/src/screens/setup-screen-model.test.ts
@@ -1,8 +1,53 @@
 import { describe, expect, it } from 'vitest';
-import { clampPlayerCount, MIN_PLAYER_COUNT } from './setup-screen-model.ts';
+import {
+  clampPlayerCount,
+  deriveSetupConfigLimits,
+  MAX_CARD_COPIES,
+  MAX_SETUP_SEED,
+  MIN_PLAYER_COUNT,
+  MIN_SETUP_SEED,
+  normalizeSeed,
+  normalizeSetupConfig,
+} from './setup-screen-model.ts';
 
 describe('clampPlayerCount', () => {
   it('falls back to the minimum when given NaN', () => {
     expect(clampPlayerCount(Number.NaN)).toBe(MIN_PLAYER_COUNT);
+  });
+
+  it('falls back to the minimum when given infinities', () => {
+    expect(clampPlayerCount(Number.POSITIVE_INFINITY)).toBe(MIN_PLAYER_COUNT);
+    expect(clampPlayerCount(Number.NEGATIVE_INFINITY)).toBe(MIN_PLAYER_COUNT);
+  });
+});
+
+describe('normalizeSeed', () => {
+  it('falls back for non-finite values and clamps to the signed 32-bit range', () => {
+    expect(normalizeSeed(Number.POSITIVE_INFINITY, 7)).toBe(7);
+    expect(normalizeSeed(Number.NEGATIVE_INFINITY, 7)).toBe(7);
+    expect(normalizeSeed(2 ** 40)).toBe(MAX_SETUP_SEED);
+    expect(normalizeSeed(-(2 ** 40))).toBe(MIN_SETUP_SEED);
+  });
+});
+
+describe('normalizeSetupConfig', () => {
+  it('caps setup-heavy values to the current deck budget', () => {
+    const normalized = normalizeSetupConfig(
+      {
+        cardCopies: 10_000,
+        deckExtractFactor: 10_000,
+        randomCardsDealt: 10_000,
+        battleTimeLimitMin: 9,
+        damageOverflowFactor: 11,
+      },
+      18,
+    );
+    const limits = deriveSetupConfigLimits(18, normalized);
+
+    expect(normalized.cardCopies).toBe(MAX_CARD_COPIES);
+    expect(normalized.deckExtractFactor).toBe(limits.deckExtractFactor);
+    expect(normalized.randomCardsDealt).toBe(limits.randomCardsDealt);
+    expect(normalized.battleTimeLimitMin).toBe(9);
+    expect(normalized.damageOverflowFactor).toBe(11);
   });
 });

--- a/packages/web/src/screens/setup-screen-model.test.ts
+++ b/packages/web/src/screens/setup-screen-model.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { clampPlayerCount, MIN_PLAYER_COUNT } from './setup-screen-model.ts';
+
+describe('clampPlayerCount', () => {
+  it('falls back to the minimum when given NaN', () => {
+    expect(clampPlayerCount(Number.NaN)).toBe(MIN_PLAYER_COUNT);
+  });
+});

--- a/packages/web/src/screens/setup-screen-model.ts
+++ b/packages/web/src/screens/setup-screen-model.ts
@@ -1,0 +1,104 @@
+import type { TeamId } from '@kurone-kito/oneiron-core';
+import {
+  type GameConfig,
+  randomStrategy,
+  type TeamControl,
+} from '@kurone-kito/oneiron-core';
+
+export type SetupValues = {
+  playerCount: number;
+  seed: number;
+  config: GameConfig;
+  controls: Map<TeamId, TeamControl>;
+};
+
+export type ControlMode = 'human' | 'bot';
+
+export type TeamSummary = {
+  readonly teamId: TeamId;
+  readonly memberCount: 1 | 2;
+  readonly teamType: 'pair' | 'solo';
+  readonly label: string;
+};
+
+const MAX_RANDOM_SEED = 2 ** 31;
+export const MIN_PLAYER_COUNT = 2;
+export const MAX_PLAYER_COUNT = 20;
+export const MAX_STARTABLE_PLAYER_COUNT = 18;
+
+export function clampPlayerCount(playerCount: number): number {
+  const normalized = Math.trunc(playerCount);
+  return Math.min(MAX_PLAYER_COUNT, Math.max(MIN_PLAYER_COUNT, normalized));
+}
+
+export function createRandomSeed(now: number = Date.now()): number {
+  const normalized = Math.abs(Math.trunc(now)) % MAX_RANDOM_SEED;
+  return normalized === 0 ? 1 : normalized;
+}
+
+export function cloneConfig(config: GameConfig): GameConfig {
+  return {
+    cardCopies: config.cardCopies,
+    deckExtractFactor: config.deckExtractFactor,
+    randomCardsDealt: config.randomCardsDealt,
+    battleTimeLimitMin: config.battleTimeLimitMin,
+    damageOverflowFactor: config.damageOverflowFactor,
+  };
+}
+
+export function deriveTeamSummaries(
+  playerCount: number,
+): readonly TeamSummary[] {
+  const teams: TeamSummary[] = [];
+  let remainingPlayers = clampPlayerCount(playerCount);
+  let teamId = 1;
+
+  while (remainingPlayers > 0) {
+    const memberCount = remainingPlayers === 1 ? 1 : 2;
+    const teamType = memberCount === 1 ? 'solo' : 'pair';
+    teams.push({
+      teamId: teamId as TeamId,
+      memberCount,
+      teamType,
+      label: `Team ${teamId} (${teamType})`,
+    });
+    remainingPlayers -= memberCount;
+    teamId += 1;
+  }
+
+  return teams;
+}
+
+export function buildControlSelections(
+  teams: readonly TeamSummary[],
+  previous: Readonly<Record<number, ControlMode>> = {},
+): Record<number, ControlMode> {
+  const next: Record<number, ControlMode> = {};
+  for (const team of teams) {
+    next[team.teamId] =
+      previous[team.teamId] ?? (team.teamId === 1 ? 'human' : 'bot');
+  }
+  return next;
+}
+
+export function buildControlsMap(
+  teams: readonly TeamSummary[],
+  selections: Readonly<Record<number, ControlMode>>,
+  seed: number,
+): Map<TeamId, TeamControl> {
+  return new Map(
+    teams.map((team) => {
+      const mode =
+        selections[team.teamId] ?? (team.teamId === 1 ? 'human' : 'bot');
+      return [
+        team.teamId,
+        mode === 'human'
+          ? { type: 'human' as const }
+          : {
+              type: 'bot' as const,
+              strategy: randomStrategy(seed + Number(team.teamId)),
+            },
+      ];
+    }),
+  );
+}

--- a/packages/web/src/screens/setup-screen-model.ts
+++ b/packages/web/src/screens/setup-screen-model.ts
@@ -22,9 +22,34 @@ export type TeamSummary = {
 };
 
 const MAX_RANDOM_SEED = 2 ** 31;
+const ELEMENT_VALUES_PER_COPY = 13;
+const ELEMENT_COUNT = 3;
+const JOKER_COUNT = 2;
+const SETUP_ELEMENT_BUFFER = 2;
+const SETUP_JOKER_DRAW_COUNT = 1;
+const MAX_SAFE_SETUP_DECK_SIZE = 1024;
+
 export const MIN_PLAYER_COUNT = 2;
 export const MAX_PLAYER_COUNT = 20;
 export const MAX_STARTABLE_PLAYER_COUNT = 18;
+export const MIN_SETUP_SEED = -(2 ** 31);
+export const MAX_SETUP_SEED = MAX_RANDOM_SEED - 1;
+export const MAX_CARD_COPIES = Math.floor(
+  (MAX_SAFE_SETUP_DECK_SIZE - JOKER_COUNT) /
+    (ELEMENT_COUNT * ELEMENT_VALUES_PER_COPY),
+);
+
+export type SetupConfigLimits = Readonly<Record<keyof GameConfig, number>>;
+
+function clampInteger(
+  value: number,
+  minimum: number,
+  maximum: number,
+  fallback: number,
+): number {
+  const normalized = Number.isFinite(value) ? Math.trunc(value) : fallback;
+  return Math.min(maximum, Math.max(minimum, normalized));
+}
 
 export function clampPlayerCount(playerCount: number): number {
   const normalized = Number.isFinite(playerCount)
@@ -36,6 +61,11 @@ export function clampPlayerCount(playerCount: number): number {
 export function createRandomSeed(now: number = Date.now()): number {
   const normalized = Math.abs(Math.trunc(now)) % MAX_RANDOM_SEED;
   return normalized === 0 ? 1 : normalized;
+}
+
+export function normalizeSeed(seed: number, fallback: number = 1): number {
+  const safeFallback = Number.isFinite(fallback) ? Math.trunc(fallback) : 1;
+  return clampInteger(seed, MIN_SETUP_SEED, MAX_SETUP_SEED, safeFallback);
 }
 
 export function cloneConfig(config: GameConfig): GameConfig {
@@ -69,6 +99,84 @@ export function deriveTeamSummaries(
   }
 
   return teams;
+}
+
+function buildDeckSize(cardCopies: number): number {
+  return ELEMENT_COUNT * ELEMENT_VALUES_PER_COPY * cardCopies + JOKER_COUNT;
+}
+
+export function deriveSetupConfigLimits(
+  playerCount: number,
+  config: GameConfig,
+): SetupConfigLimits {
+  const teamCount = deriveTeamSummaries(playerCount).length;
+  const cardCopies = clampInteger(config.cardCopies, 1, MAX_CARD_COPIES, 1);
+  const maxDeckExtractFactor = Math.max(
+    1,
+    Math.floor(
+      (ELEMENT_VALUES_PER_COPY * cardCopies - SETUP_ELEMENT_BUFFER) / teamCount,
+    ),
+  );
+  const deckExtractFactor = clampInteger(
+    config.deckExtractFactor,
+    1,
+    maxDeckExtractFactor,
+    1,
+  );
+  const remainingAfterSetup =
+    buildDeckSize(cardCopies) -
+    (ELEMENT_COUNT * (teamCount * deckExtractFactor + SETUP_ELEMENT_BUFFER) +
+      SETUP_JOKER_DRAW_COUNT);
+  return {
+    cardCopies: MAX_CARD_COPIES,
+    deckExtractFactor: maxDeckExtractFactor,
+    randomCardsDealt: Math.max(0, Math.floor(remainingAfterSetup / teamCount)),
+    battleTimeLimitMin: MAX_SETUP_SEED,
+    damageOverflowFactor: MAX_SETUP_SEED,
+  };
+}
+
+export function normalizeSetupConfig(
+  config: GameConfig,
+  playerCount: number,
+): GameConfig {
+  const cardCopies = clampInteger(config.cardCopies, 1, MAX_CARD_COPIES, 1);
+  const provisionalConfig = {
+    ...config,
+    cardCopies,
+  };
+  const deckExtractFactor = clampInteger(
+    config.deckExtractFactor,
+    1,
+    deriveSetupConfigLimits(playerCount, provisionalConfig).deckExtractFactor,
+    1,
+  );
+  const limits = deriveSetupConfigLimits(playerCount, {
+    ...provisionalConfig,
+    deckExtractFactor,
+  });
+  return {
+    cardCopies,
+    deckExtractFactor,
+    randomCardsDealt: clampInteger(
+      config.randomCardsDealt,
+      0,
+      limits.randomCardsDealt,
+      0,
+    ),
+    battleTimeLimitMin: clampInteger(
+      config.battleTimeLimitMin,
+      1,
+      limits.battleTimeLimitMin,
+      1,
+    ),
+    damageOverflowFactor: clampInteger(
+      config.damageOverflowFactor,
+      1,
+      limits.damageOverflowFactor,
+      1,
+    ),
+  };
 }
 
 export function buildControlSelections(

--- a/packages/web/src/screens/setup-screen-model.ts
+++ b/packages/web/src/screens/setup-screen-model.ts
@@ -202,6 +202,7 @@ export function buildControlsMap(
 ): Map<TeamId, TeamControl> {
   return new Map(
     teams.map((team) => {
+      // Defensive fallback in case a caller bypasses buildControlSelections().
       const mode =
         selections[team.teamId] ?? (team.teamId === 1 ? 'human' : 'bot');
       return [

--- a/packages/web/src/screens/setup-screen-model.ts
+++ b/packages/web/src/screens/setup-screen-model.ts
@@ -28,6 +28,7 @@ const JOKER_COUNT = 2;
 const SETUP_ELEMENT_BUFFER = 2;
 const SETUP_JOKER_DRAW_COUNT = 1;
 const MAX_SAFE_SETUP_DECK_SIZE = 1024;
+const MAX_CONFIG_INTEGER = Number.MAX_SAFE_INTEGER;
 
 export const MIN_PLAYER_COUNT = 2;
 export const MAX_PLAYER_COUNT = 20;
@@ -39,7 +40,12 @@ export const MAX_CARD_COPIES = Math.floor(
     (ELEMENT_COUNT * ELEMENT_VALUES_PER_COPY),
 );
 
-export type SetupConfigLimits = Readonly<Record<keyof GameConfig, number>>;
+export type SetupConfigLimits = Readonly<
+  Pick<
+    Record<keyof GameConfig, number>,
+    'cardCopies' | 'deckExtractFactor' | 'randomCardsDealt'
+  >
+>;
 
 function clampInteger(
   value: number,
@@ -131,8 +137,6 @@ export function deriveSetupConfigLimits(
     cardCopies: MAX_CARD_COPIES,
     deckExtractFactor: maxDeckExtractFactor,
     randomCardsDealt: Math.max(0, Math.floor(remainingAfterSetup / teamCount)),
-    battleTimeLimitMin: MAX_SETUP_SEED,
-    damageOverflowFactor: MAX_SETUP_SEED,
   };
 }
 
@@ -167,13 +171,13 @@ export function normalizeSetupConfig(
     battleTimeLimitMin: clampInteger(
       config.battleTimeLimitMin,
       1,
-      limits.battleTimeLimitMin,
+      MAX_CONFIG_INTEGER,
       1,
     ),
     damageOverflowFactor: clampInteger(
       config.damageOverflowFactor,
       1,
-      limits.damageOverflowFactor,
+      MAX_CONFIG_INTEGER,
       1,
     ),
   };

--- a/packages/web/src/screens/setup-screen-model.ts
+++ b/packages/web/src/screens/setup-screen-model.ts
@@ -27,7 +27,9 @@ export const MAX_PLAYER_COUNT = 20;
 export const MAX_STARTABLE_PLAYER_COUNT = 18;
 
 export function clampPlayerCount(playerCount: number): number {
-  const normalized = Math.trunc(playerCount);
+  const normalized = Number.isFinite(playerCount)
+    ? Math.trunc(playerCount)
+    : MIN_PLAYER_COUNT;
   return Math.min(MAX_PLAYER_COUNT, Math.max(MIN_PLAYER_COUNT, normalized));
 }
 


### PR DESCRIPTION
## Summary
- add a `SetupScreen` for player count, seed randomization, per-team controls, and A-E config overrides
- replace the demo `App` with a `setup` / `playing` state machine that starts `setupGame` + `createSession`
- cover setup rendering, team derivation, sanitized config submission, and the App-level transition with web tests

## Testing
- pnpm run lint:fix
- pnpm -r typecheck
- pnpm run test
- pnpm --filter @kurone-kito/oneiron-web run build
- pnpm run lint

Closes #125

## Follow-ups
- #126 will replace the placeholder playing panel with the full gameplay UI.

## Notes
- The setup form keeps the requested `2..20` player-count input, but it now warns and blocks submission above 18 players because the current 3x3 core grid can host at most 9 teams.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dream Duels Setup screen: player count, seed (randomise), per-team human/bot selectors, collapsible config panels, start gating with capped-player warning, and transition to playing with session summary and game grid showing current phase.
  * Inputs validated/sanitized; config fields clamped to safe limits; session shows configured controls.

* **Refactor**
  * App flow updated to a state-driven setup → playing switch and driven game-grid view.

* **Tests**
  * Expanded coverage for setup UI, seed behavior, control mappings, config sanitization/clamping, start gating, and app flow transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->