### PR TITLE
feat(cli): scaffold packages/cli workspace package

### DIFF
--- a/packages/cli/bin/oneiron.js
+++ b/packages/cli/bin/oneiron.js
@@ -1,22 +1,97 @@
 #!/usr/bin/env node
 
-import { spawnSync } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
 
-const currentDirectory = dirname(fileURLToPath(import.meta.url));
-const cliPath = resolve(currentDirectory, '../src/cli.ts');
+const HELP_TEXT = `oneiron - headless Dream Duels simulator
 
-const result = spawnSync(
-  process.execPath,
-  ['--experimental-strip-types', cliPath, ...process.argv.slice(2)],
-  {
-    stdio: 'inherit',
+Usage:
+  oneiron [options]
+
+Options:
+  -h, --help     Show this help message
+  -v, --version  Show the CLI package version`;
+
+const READY_TEXT = 'oneiron-cli ready';
+const FALLBACK_VERSION = '0.0.0';
+const SAFE_VERSION_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+const options = {
+  help: {
+    short: 'h',
+    type: 'boolean',
   },
-);
+  version: {
+    short: 'v',
+    type: 'boolean',
+  },
+};
 
-if (result.error !== undefined) {
-  throw result.error;
-}
+const readPackageVersion = async () => {
+  try {
+    const packageUrl = new URL('../package.json', import.meta.url);
+    const packageJson = await readFile(packageUrl, 'utf8');
+    const parsedPackage = JSON.parse(packageJson);
+    const rawVersion = parsedPackage.version;
 
-process.exitCode = result.status ?? 1;
+    if (typeof rawVersion !== 'string') {
+      return FALLBACK_VERSION;
+    }
+
+    const sanitizedVersion = [...rawVersion]
+      .filter((character) => character >= ' ' && character !== '\u007f')
+      .join('');
+
+    if (!SAFE_VERSION_PATTERN.test(sanitizedVersion)) {
+      return FALLBACK_VERSION;
+    }
+
+    return sanitizedVersion;
+  } catch {
+    return FALLBACK_VERSION;
+  }
+};
+
+const readErrorMessage = (error) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+const runCli = async (argv = process.argv.slice(2)) => {
+  let help = false;
+  let version = false;
+
+  try {
+    ({
+      values: { help = false, version = false },
+    } = parseArgs({
+      args: [...argv],
+      options,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.error(readErrorMessage(error));
+    console.error('');
+    console.error(HELP_TEXT);
+    return 1;
+  }
+
+  if (help) {
+    console.log(HELP_TEXT);
+    return 0;
+  }
+
+  if (version) {
+    console.log(await readPackageVersion());
+    return 0;
+  }
+
+  console.log(READY_TEXT);
+  return 0;
+};
+
+process.exitCode = await runCli();

--- a/packages/cli/bin/oneiron.js
+++ b/packages/cli/bin/oneiron.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDirectory = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(currentDirectory, '../src/cli.ts');
+
+const result = spawnSync(
+  process.execPath,
+  ['--experimental-strip-types', cliPath, ...process.argv.slice(2)],
+  {
+    stdio: 'inherit',
+  },
+);
+
+if (result.error !== undefined) {
+  throw result.error;
+}
+
+process.exitCode = result.status ?? 1;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
   "author": "kurone-kito <krone@kit.black> (https://kit.black/)",
   "type": "module",
   "bin": {
-    "oneiron": "./src/cli.ts"
+    "oneiron": "./bin/oneiron.js"
   },
   "scripts": {
     "start": "tsx src/cli.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
     "oneiron"
   ],
   "homepage": "https://github.com/kurone-kito/oneiron#readme",
+  "bugs": "https://github.com/kurone-kito/oneiron/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/kurone-kito/oneiron.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@kurone-kito/oneiron-cli",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Dream Duels: The Battle for Oneiron — headless CLI entrypoint.",
+  "keywords": [
+    "battle-royale",
+    "card-game",
+    "cli",
+    "dream-duels",
+    "oneiron"
+  ],
+  "homepage": "https://github.com/kurone-kito/oneiron#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kurone-kito/oneiron.git",
+    "directory": "packages/cli"
+  },
+  "license": "MIT",
+  "author": "kurone-kito <krone@kit.black> (https://kit.black/)",
+  "type": "module",
+  "bin": {
+    "oneiron": "./src/cli.ts"
+  },
+  "scripts": {
+    "start": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kurone-kito/oneiron-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@kurone-kito/typescript-config": "^0.22.0-alpha.9",
+    "tsx": "^4.8.1"
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -13,6 +13,9 @@ Options:
   -v, --version  Show the CLI package version`;
 
 const READY_TEXT = 'oneiron-cli ready';
+const FALLBACK_VERSION = '0.0.0';
+const SAFE_VERSION_PATTERN =
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 const options = {
   help: {
@@ -29,8 +32,21 @@ const readPackageVersion = async (): Promise<string> => {
   const packageUrl = new URL('../package.json', import.meta.url);
   const packageJson = await readFile(packageUrl, 'utf8');
   const parsedPackage = JSON.parse(packageJson) as { version?: string };
+  const rawVersion = parsedPackage.version;
 
-  return parsedPackage.version ?? '0.0.0';
+  if (typeof rawVersion !== 'string') {
+    return FALLBACK_VERSION;
+  }
+
+  const sanitizedVersion = [...rawVersion]
+    .filter((character) => character >= ' ' && character !== '\u007f')
+    .join('');
+
+  if (!SAFE_VERSION_PATTERN.test(sanitizedVersion)) {
+    return FALLBACK_VERSION;
+  }
+
+  return sanitizedVersion;
 };
 
 const readErrorMessage = (error: unknown): string => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env -S node --experimental-strip-types
+
+import { readFile } from 'node:fs/promises';
+import { parseArgs } from 'node:util';
+
+const HELP_TEXT = `oneiron - headless Dream Duels simulator
+
+Usage:
+  oneiron [options]
+
+Options:
+  -h, --help     Show this help message
+  -v, --version  Show the CLI package version`;
+
+const READY_TEXT = 'oneiron-cli ready';
+
+const options = {
+  help: {
+    short: 'h',
+    type: 'boolean',
+  },
+  version: {
+    short: 'v',
+    type: 'boolean',
+  },
+} as const;
+
+const readPackageVersion = async (): Promise<string> => {
+  const packageUrl = new URL('../package.json', import.meta.url);
+  const packageJson = await readFile(packageUrl, 'utf8');
+  const parsedPackage = JSON.parse(packageJson) as { version?: string };
+
+  return parsedPackage.version ?? '0.0.0';
+};
+
+const readErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+export const runCli = async (
+  argv: readonly string[] = process.argv.slice(2),
+): Promise<number> => {
+  let help = false;
+  let version = false;
+
+  try {
+    ({
+      values: { help = false, version = false },
+    } = parseArgs({
+      args: [...argv],
+      options,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.log(readErrorMessage(error));
+    console.log('');
+    console.log(HELP_TEXT);
+    return 1;
+  }
+
+  if (help) {
+    console.log(HELP_TEXT);
+    return 0;
+  }
+
+  if (version) {
+    console.log(await readPackageVersion());
+    return 0;
+  }
+
+  console.log(READY_TEXT);
+  return 0;
+};
+
+const exitCode = await runCli();
+process.exitCode = exitCode;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
 import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
 const HELP_TEXT = `oneiron - headless Dream Duels simulator
@@ -29,24 +30,28 @@ const options = {
 } as const;
 
 const readPackageVersion = async (): Promise<string> => {
-  const packageUrl = new URL('../package.json', import.meta.url);
-  const packageJson = await readFile(packageUrl, 'utf8');
-  const parsedPackage = JSON.parse(packageJson) as { version?: string };
-  const rawVersion = parsedPackage.version;
+  try {
+    const packageUrl = new URL('../package.json', import.meta.url);
+    const packageJson = await readFile(packageUrl, 'utf8');
+    const parsedPackage = JSON.parse(packageJson) as { version?: string };
+    const rawVersion = parsedPackage.version;
 
-  if (typeof rawVersion !== 'string') {
+    if (typeof rawVersion !== 'string') {
+      return FALLBACK_VERSION;
+    }
+
+    const sanitizedVersion = [...rawVersion]
+      .filter((character) => character >= ' ' && character !== '\u007f')
+      .join('');
+
+    if (!SAFE_VERSION_PATTERN.test(sanitizedVersion)) {
+      return FALLBACK_VERSION;
+    }
+
+    return sanitizedVersion;
+  } catch {
     return FALLBACK_VERSION;
   }
-
-  const sanitizedVersion = [...rawVersion]
-    .filter((character) => character >= ' ' && character !== '\u007f')
-    .join('');
-
-  if (!SAFE_VERSION_PATTERN.test(sanitizedVersion)) {
-    return FALLBACK_VERSION;
-  }
-
-  return sanitizedVersion;
 };
 
 const readErrorMessage = (error: unknown): string => {
@@ -92,5 +97,16 @@ export const runCli = async (
   return 0;
 };
 
-const exitCode = await runCli();
-process.exitCode = exitCode;
+const isDirectExecution = (): boolean => {
+  const entryPoint = process.argv[1];
+
+  return (
+    entryPoint !== undefined &&
+    pathToFileURL(entryPoint).href === import.meta.url
+  );
+};
+
+if (isDirectExecution()) {
+  const exitCode = await runCli();
+  process.exitCode = exitCode;
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -56,9 +56,9 @@ export const runCli = async (
       allowPositionals: false,
     }));
   } catch (error) {
-    console.log(readErrorMessage(error));
-    console.log('');
-    console.log(HELP_TEXT);
+    console.error(readErrorMessage(error));
+    console.error('');
+    console.error(HELP_TEXT);
     return 1;
   }
 

--- a/packages/cli/src/node-runtime.d.ts
+++ b/packages/cli/src/node-runtime.d.ts
@@ -5,6 +5,7 @@
  */
 
 declare class URL {
+  href: string;
   constructor(input: string, base?: string);
 }
 
@@ -44,4 +45,8 @@ declare module 'node:util' {
     values: Record<string, boolean | undefined>;
     positionals: string[];
   };
+}
+
+declare module 'node:url' {
+  export function pathToFileURL(path: string): URL;
 }

--- a/packages/cli/src/node-runtime.d.ts
+++ b/packages/cli/src/node-runtime.d.ts
@@ -9,6 +9,7 @@ declare class URL {
 }
 
 declare const console: {
+  error: (...data: unknown[]) => void;
   log: (...data: unknown[]) => void;
 };
 

--- a/packages/cli/src/node-runtime.d.ts
+++ b/packages/cli/src/node-runtime.d.ts
@@ -1,0 +1,46 @@
+/*
+ * Minimal Node runtime declarations for CLI v1.
+ * This keeps the scaffold package typecheckable without expanding the
+ * dependency surface beyond the issue's requested baseline.
+ */
+
+declare class URL {
+  constructor(input: string, base?: string);
+}
+
+declare const console: {
+  log: (...data: unknown[]) => void;
+};
+
+declare const process: {
+  argv: string[];
+  exitCode?: number;
+};
+
+interface ImportMeta {
+  url: string;
+}
+
+declare module 'node:fs/promises' {
+  export function readFile(
+    path: string | URL,
+    encoding: string,
+  ): Promise<string>;
+}
+
+declare module 'node:util' {
+  export function parseArgs(config: {
+    args?: readonly string[];
+    options?: Record<
+      string,
+      {
+        short?: string;
+        type: 'boolean';
+      }
+    >;
+    allowPositionals?: boolean;
+  }): {
+    values: Record<string, boolean | undefined>;
+    positionals: string[];
+  };
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@kurone-kito/typescript-config",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "src",
+    "types": []
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
         version: 0.22.0-alpha.9(typescript@6.0.3)
       '@vitest/coverage-v8':
         specifier: ^3.2.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
       cspell:
         specifier: ^10.0.0
         version: 10.0.0
@@ -63,7 +63,20 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^3.2.0
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
+
+  packages/cli:
+    dependencies:
+      '@kurone-kito/oneiron-core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@kurone-kito/typescript-config':
+        specifier: ^0.22.0-alpha.9
+        version: 0.22.0-alpha.9(typescript@6.0.3)
+      tsx:
+        specifier: ^4.8.1
+        version: 4.22.3
 
   packages/core: {}
 
@@ -84,13 +97,13 @@ importers:
         version: 20.9.0
       vite:
         specifier: ^6.3.5
-        version: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+        version: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
       vite-plugin-solid:
         specifier: ^2.11.6
-        version: 2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
+        version: 2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
 
 packages:
 
@@ -565,8 +578,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -577,8 +602,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -589,8 +626,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -601,8 +650,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -613,8 +674,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -625,8 +698,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -637,8 +722,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -649,8 +746,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -661,8 +770,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -673,8 +794,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -685,8 +818,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -697,8 +842,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -709,8 +866,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1012,18 +1181,6 @@ packages:
 
   '@types/node@25.8.0':
     resolution: {integrity: sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==}
-
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
-  '@types/react-is@17.0.7':
-    resolution: {integrity: sha512-WrTEiT+c6rgq36QApoy0063uAOdltCrhF0QMXLIgYPaTvIdQhAB8hPb5oGGqX18xToElNILS9UprwU6GyINcJg==}
-
-  '@types/react@17.0.91':
-    resolution: {integrity: sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1391,6 +1548,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2090,6 +2252,11 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2772,79 +2939,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@isaacs/cliui@8.0.2':
@@ -3064,20 +3309,6 @@ snapshots:
     dependencies:
       undici-types: 7.24.6
 
-  '@types/prop-types@15.7.15': {}
-
-  '@types/react-is@17.0.7':
-    dependencies:
-      '@types/react': 17.0.91
-
-  '@types/react@17.0.91':
-    dependencies:
-      '@types/prop-types': 15.7.15
-      '@types/scheduler': 0.16.8
-      csstype: 3.2.3
-
-  '@types/scheduler@0.16.8': {}
-
   '@types/unist@2.0.11': {}
 
   '@types/whatwg-mimetype@3.0.2': {}
@@ -3086,7 +3317,7 @@ snapshots:
     dependencies:
       '@types/node': 25.8.0
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -3101,7 +3332,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -3113,13 +3344,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -3505,6 +3736,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.2.0: {}
 
@@ -4095,7 +4355,6 @@ snapshots:
 
   pretty-format@27.5.1:
     dependencies:
-      '@types/react-is': 17.0.7
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
@@ -4289,6 +4548,12 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
@@ -4303,13 +4568,13 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite-node@3.2.4(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4324,7 +4589,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vite-plugin-solid@2.11.12(solid-js@1.9.13)(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.0
       '@types/babel__core': 7.20.5
@@ -4332,12 +4597,12 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.13
       solid-refresh: 0.6.3(solid-js@1.9.13)
-      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
+      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0):
+  vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -4349,17 +4614,18 @@ snapshots:
       '@types/node': 25.8.0
       fsevents: 2.3.3
       jiti: 2.6.1
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(yaml@2.9.0):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.8.0)(happy-dom@20.9.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -4377,8 +4643,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.8.0)(jiti@2.6.1)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@25.8.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13


### PR DESCRIPTION
## Summary
- scaffold a new `packages/cli` workspace package with `start` and `typecheck` scripts
- add a minimal `src/cli.ts` entrypoint with `--help`, `--version`, and friendly usage errors
- wire the package into the workspace lockfile while keeping follow-up simulation work for later issues

## Validation
- `corepack enable && pnpm install`
- `pnpm --filter @kurone-kito/oneiron-cli run start --help`
- `./packages/cli/src/cli.ts --version`
- `pnpm run test`
- `pnpm -r typecheck`
- `pnpm run lint`

## Follow-ups
- `#129` adds the actual batch simulation runner on top of this scaffold
- `#130` builds report output once batch runs exist

## Notes
- the declared CLI `bin` uses Node 22's `--experimental-strip-types` for direct execution, while the package `start` script still uses `tsx` for the requested workspace-local TypeScript workflow

Closes #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI package providing a command-line tool with --help and --version flags, startup/ready output, parse-error handling, and stable exit codes.

* **Documentation / Types**
  * Added minimal runtime type declarations for improved editor/type support.
  * Introduced a dedicated TypeScript configuration for the CLI to enforce checks.

* **Chores**
  * Added package manifest, package scripts (start/typecheck), and an executable entry to run the CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->