### PR TITLE
feat(cli): batch runner — execute N games and collect outcomes

### DIFF
--- a/packages/cli/src/batch.test.ts
+++ b/packages/cli/src/batch.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { runBatch } from './batch.ts';
+
+describe('runBatch', () => {
+  it('returns one outcome per game', () => {
+    const { outcomes } = runBatch({
+      playerCount: 4,
+      seedStart: 1,
+      gameCount: 10,
+    });
+    expect(outcomes).toHaveLength(10);
+    for (const outcome of outcomes) {
+      expect(outcome.seed).toBeGreaterThanOrEqual(1);
+      expect(outcome.rounds).toBeGreaterThan(0);
+      expect(outcome.rounds).toBeLessThanOrEqual(50);
+      expect(outcome.totalDamageDealt).toBeGreaterThanOrEqual(0);
+      expect(outcome.graveyardSize).toBeGreaterThanOrEqual(0);
+      expect(Array.isArray(outcome.survivingTeams)).toBe(true);
+    }
+  });
+
+  it('uses consecutive seeds starting at seedStart', () => {
+    const { outcomes } = runBatch({
+      playerCount: 4,
+      seedStart: 100,
+      gameCount: 5,
+    });
+    expect(outcomes.map((o) => o.seed)).toEqual([100, 101, 102, 103, 104]);
+  });
+
+  it('is deterministic for the same input', () => {
+    const input = {
+      playerCount: 4,
+      seedStart: 42,
+      gameCount: 5,
+      strategySeed: 7,
+    } as const;
+    const first = runBatch(input);
+    const second = runBatch(input);
+    expect(first).toEqual(second);
+  });
+
+  it('respects maxRoundsPerGame as an upper bound', () => {
+    const { outcomes } = runBatch({
+      playerCount: 6,
+      seedStart: 1,
+      gameCount: 5,
+      maxRoundsPerGame: 10,
+    });
+    expect(outcomes).toHaveLength(5);
+    for (const outcome of outcomes) {
+      expect(outcome.rounds).toBeLessThanOrEqual(10);
+    }
+  });
+
+  it('marks a clear winner when only one team survives', () => {
+    const { outcomes } = runBatch({
+      playerCount: 4,
+      seedStart: 1,
+      gameCount: 20,
+    });
+    for (const outcome of outcomes) {
+      if (outcome.winner !== null) {
+        expect(outcome.survivingTeams).toContain(outcome.winner);
+      }
+    }
+  });
+
+  it('changing strategySeed changes outcomes', () => {
+    const a = runBatch({
+      playerCount: 4,
+      seedStart: 1,
+      gameCount: 3,
+      strategySeed: 0,
+    });
+    const b = runBatch({
+      playerCount: 4,
+      seedStart: 1,
+      gameCount: 3,
+      strategySeed: 999,
+    });
+    expect(a).not.toEqual(b);
+  });
+});

--- a/packages/cli/src/batch.ts
+++ b/packages/cli/src/batch.ts
@@ -1,0 +1,176 @@
+import {
+  type BattlePlay,
+  DEFAULT_CONFIG,
+  type GameConfig,
+  isGameOver,
+  isTeamAlive,
+  type MovementChoice,
+  type RevivalAction,
+  type RoundInputs,
+  type RoundState,
+  randomStrategy,
+  runRound,
+  type StrategyMovementChoice,
+  setupGame,
+  type TeamId,
+  type TeamState,
+  type TeamStrategy,
+  winner as winnerOf,
+} from '@kurone-kito/oneiron-core';
+
+const GRID_AXES = ['fire', 'water', 'wood'] as const;
+
+function listAllTeams(state: RoundState): TeamState[] {
+  const teams: TeamState[] = [];
+  for (const x of GRID_AXES) {
+    for (const y of GRID_AXES) {
+      for (const team of state.grid[x][y]) {
+        teams.push(team);
+      }
+    }
+  }
+  return teams;
+}
+
+const DEFAULT_MAX_ROUNDS_PER_GAME = 50;
+const DEFAULT_STRATEGY_SEED = 0;
+
+export type BatchInput = {
+  readonly playerCount: number;
+  readonly seedStart: number;
+  readonly gameCount: number;
+  readonly maxRoundsPerGame?: number;
+  readonly config?: GameConfig;
+  readonly strategySeed?: number;
+};
+
+export type GameOutcome = {
+  readonly seed: number;
+  readonly winner: TeamId | null;
+  readonly rounds: number;
+  readonly survivingTeams: readonly TeamId[];
+  readonly totalDamageDealt: number;
+  readonly graveyardSize: number;
+};
+
+export type BatchOutput = {
+  readonly outcomes: readonly GameOutcome[];
+};
+
+function buildStrategies(
+  state: RoundState,
+  strategySeed: number,
+): ReadonlyMap<TeamId, TeamStrategy> {
+  const strategies = new Map<TeamId, TeamStrategy>();
+  for (const team of listAllTeams(state)) {
+    strategies.set(
+      team.teamNumber,
+      randomStrategy(strategySeed + team.teamNumber),
+    );
+  }
+  return strategies;
+}
+
+function normalizeMovementChoice(
+  team: TeamState,
+  choice: StrategyMovementChoice,
+): MovementChoice {
+  // The InputProvider runs at round-start, but movement resolution
+  // happens after battle has consumed cards. An explicit pick that
+  // names the card battle consumed (or a 1-card hand that loses its
+  // only card to battle) would throw inside resolveMovementChoices,
+  // so always demote to emergency-draw — its fallback path picks
+  // team.cards[0] when the hand is non-empty and draws fresh cards
+  // when it is empty. This is sub-optimal compared to a hand-aware
+  // pick, but it never strands the round and keeps random bots
+  // deterministic across runs.
+  const base = {
+    teamId: team.teamNumber,
+    kind: 'emergency-draw' as const,
+    intendedFacing: choice.intendedFacing,
+  };
+  return choice.gridSwapIndex !== undefined
+    ? { ...base, gridSwapIndex: choice.gridSwapIndex }
+    : base;
+}
+
+function makeInputProvider(
+  strategies: ReadonlyMap<TeamId, TeamStrategy>,
+): (state: RoundState) => RoundInputs {
+  return (state) => {
+    const livingTeams = listAllTeams(state).filter(isTeamAlive);
+    const plays: BattlePlay[] = [];
+    const teamMoves: MovementChoice[] = [];
+    const revivalChoices = new Map<TeamId, RevivalAction>();
+
+    for (const team of livingTeams) {
+      const strategy = strategies.get(team.teamNumber);
+      if (strategy === undefined) continue;
+
+      const battle = strategy.chooseBattlePlay(state, team.teamNumber);
+      plays.push({ teamId: team.teamNumber, card: battle.card });
+
+      const movement = strategy.chooseTeamMove(state, team.teamNumber);
+      if (movement !== null) {
+        teamMoves.push(normalizeMovementChoice(team, movement));
+      }
+
+      const revival = strategy.chooseRevivalAction(state, team.teamNumber);
+      if (revival !== null) {
+        revivalChoices.set(team.teamNumber, revival);
+      }
+    }
+
+    return {
+      battle: { plays },
+      movement: { teamMoves },
+      revival: { choices: revivalChoices },
+    };
+  };
+}
+
+export function runBatch(input: BatchInput): BatchOutput {
+  const maxRounds = input.maxRoundsPerGame ?? DEFAULT_MAX_ROUNDS_PER_GAME;
+  const gameConfig = input.config ?? DEFAULT_CONFIG;
+  const strategySeed = input.strategySeed ?? DEFAULT_STRATEGY_SEED;
+
+  const outcomes: GameOutcome[] = [];
+  for (let i = 0; i < input.gameCount; i += 1) {
+    const seed = input.seedStart + i;
+    const initial = setupGame(
+      { playerCount: input.playerCount, seed },
+      gameConfig,
+    );
+    const strategies = buildStrategies(initial, strategySeed);
+    const inputProvider = makeInputProvider(strategies);
+
+    let current = initial;
+    let rounds = 0;
+    let totalDamageDealt = 0;
+
+    while (rounds < maxRounds && !isGameOver(current)) {
+      const inputs = inputProvider(current);
+      const round = runRound(current, inputs);
+      for (const result of round.battleResults) {
+        totalDamageDealt += result.damage;
+      }
+      current = round.state;
+      rounds += 1;
+    }
+
+    const survivingTeams = listAllTeams(current)
+      .filter(isTeamAlive)
+      .map((team) => team.teamNumber);
+
+    outcomes.push({
+      seed,
+      winner: winnerOf(current),
+      rounds,
+      survivingTeams,
+      totalDamageDealt,
+      graveyardSize: current.graveyard?.length ?? 0,
+    });
+  }
+
+  return { outcomes };
+}

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runCli } from './cli.ts';
+
+describe('runCli', () => {
+  let stdout: string[];
+  let stderr: string[];
+
+  beforeEach(() => {
+    stdout = [];
+    stderr = [];
+    vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+      stdout.push(typeof value === 'string' ? value : String(value));
+    });
+    vi.spyOn(console, 'error').mockImplementation((value?: unknown) => {
+      stderr.push(typeof value === 'string' ? value : String(value));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints the ready text when no arguments are passed', async () => {
+    const code = await runCli([]);
+    expect(code).toBe(0);
+    expect(stdout.join('\n')).toContain('oneiron-cli ready');
+  });
+
+  it('prints help text when --help is passed', async () => {
+    const code = await runCli(['--help']);
+    expect(code).toBe(0);
+    expect(stdout.join('\n')).toContain('Usage:');
+    expect(stdout.join('\n')).toContain('batch');
+  });
+
+  describe('batch subcommand', () => {
+    it('prints JSON with one outcome per game on success', async () => {
+      const code = await runCli([
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        '3',
+        '--seed-start',
+        '1',
+      ]);
+      expect(code).toBe(0);
+      expect(stdout).toHaveLength(1);
+      const parsed = JSON.parse(stdout[0] ?? '') as {
+        outcomes: readonly { seed: number }[];
+      };
+      expect(parsed.outcomes).toHaveLength(3);
+      expect(parsed.outcomes.map((o) => o.seed)).toEqual([1, 2, 3]);
+    });
+
+    it('produces identical JSON across runs with the same flags', async () => {
+      const flags = [
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        '2',
+        '--seed-start',
+        '7',
+        '--strategy-seed',
+        '11',
+      ] as const;
+      const first = await runCli([...flags]);
+      const firstOut = stdout[0];
+      stdout.length = 0;
+      const second = await runCli([...flags]);
+      const secondOut = stdout[0];
+      expect(first).toBe(0);
+      expect(second).toBe(0);
+      expect(firstOut).toBe(secondOut);
+    });
+
+    it('exits with code 1 when --player-count is missing', async () => {
+      const code = await runCli(['batch', '--games', '1']);
+      expect(code).toBe(1);
+      expect(stderr.join('\n')).toContain('player-count');
+    });
+
+    it('exits with code 1 when --games is missing', async () => {
+      const code = await runCli(['batch', '--player-count', '4']);
+      expect(code).toBe(1);
+      expect(stderr.join('\n')).toContain('games');
+    });
+
+    it('rejects non-integer values', async () => {
+      const code = await runCli([
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        'abc',
+      ]);
+      expect(code).toBe(1);
+      expect(stderr.join('\n')).toContain('Invalid integer');
+    });
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,20 +3,35 @@
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
+import { runBatch } from './batch.ts';
 
 const HELP_TEXT = `oneiron - headless Dream Duels simulator
 
 Usage:
   oneiron [options]
+  oneiron batch [batch-options]
 
 Options:
   -h, --help     Show this help message
-  -v, --version  Show the CLI package version`;
+  -v, --version  Show the CLI package version
+
+Subcommands:
+  batch          Run N games and print outcome JSON to stdout
+
+Batch options:
+  --player-count <n>    Number of teams (required)
+  --games <n>           Number of games to run (required)
+  --seed-start <n>      Seed for the first game (default 0)
+  --max-rounds <n>      Max rounds per game (default 50)
+  --strategy-seed <n>   Base seed for bot strategies (default 0)`;
 
 const READY_TEXT = 'oneiron-cli ready';
 const FALLBACK_VERSION = '0.0.0';
 const SAFE_VERSION_PATTERN =
   /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+const DEFAULT_BATCH_SEED_START = 0;
+const DEFAULT_BATCH_MAX_ROUNDS = 50;
+const DEFAULT_BATCH_STRATEGY_SEED = 0;
 
 const options = {
   help: {
@@ -28,6 +43,22 @@ const options = {
     type: 'boolean',
   },
 } as const;
+
+const batchOptions = {
+  'player-count': { type: 'string' },
+  games: { type: 'string' },
+  'seed-start': { type: 'string' },
+  'max-rounds': { type: 'string' },
+  'strategy-seed': { type: 'string' },
+} as const;
+
+const readErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
 
 const readPackageVersion = async (): Promise<string> => {
   try {
@@ -54,24 +85,94 @@ const readPackageVersion = async (): Promise<string> => {
   }
 };
 
-const readErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message;
+const parsePositiveInt = (name: string, raw: string | undefined): number => {
+  if (raw === undefined) {
+    throw new Error(`Missing required option: --${name}`);
+  }
+  if (!/^-?\d+$/.test(raw)) {
+    throw new Error(`Invalid integer for --${name}: ${raw}`);
+  }
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`--${name} must be a positive integer`);
+  }
+  return value;
+};
+
+const parseOptionalInt = (
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+): number => {
+  if (raw === undefined) return fallback;
+  if (!/^-?\d+$/.test(raw)) {
+    throw new Error(`Invalid integer for --${name}: ${raw}`);
+  }
+  return Number.parseInt(raw, 10);
+};
+
+const runBatchCommand = (argv: readonly string[]): number => {
+  let values: {
+    readonly [K in keyof typeof batchOptions]?: string;
+  };
+  try {
+    ({ values } = parseArgs({
+      args: [...argv],
+      options: batchOptions,
+      allowPositionals: false,
+    }));
+  } catch (error) {
+    console.error(readErrorMessage(error));
+    console.error('');
+    console.error(HELP_TEXT);
+    return 1;
   }
 
-  return String(error);
+  try {
+    const playerCount = parsePositiveInt(
+      'player-count',
+      values['player-count'],
+    );
+    const gameCount = parsePositiveInt('games', values.games);
+    const seedStart = parseOptionalInt(
+      'seed-start',
+      values['seed-start'],
+      DEFAULT_BATCH_SEED_START,
+    );
+    const maxRoundsPerGame = parsePositiveInt(
+      'max-rounds',
+      values['max-rounds'] ?? String(DEFAULT_BATCH_MAX_ROUNDS),
+    );
+    const strategySeed = parseOptionalInt(
+      'strategy-seed',
+      values['strategy-seed'],
+      DEFAULT_BATCH_STRATEGY_SEED,
+    );
+    const output = runBatch({
+      playerCount,
+      gameCount,
+      seedStart,
+      maxRoundsPerGame,
+      strategySeed,
+    });
+    console.log(JSON.stringify(output));
+    return 0;
+  } catch (error) {
+    console.error(readErrorMessage(error));
+    return 1;
+  }
 };
 
 export const runCli = async (
   argv: readonly string[] = process.argv.slice(2),
 ): Promise<number> => {
-  let help = false;
-  let version = false;
+  if (argv[0] === 'batch') {
+    return runBatchCommand(argv.slice(1));
+  }
 
+  let values: Record<string, boolean | string | undefined>;
   try {
-    ({
-      values: { help = false, version = false },
-    } = parseArgs({
+    ({ values } = parseArgs({
       args: [...argv],
       options,
       allowPositionals: false,
@@ -83,12 +184,12 @@ export const runCli = async (
     return 1;
   }
 
-  if (help) {
+  if (values['help'] === true) {
     console.log(HELP_TEXT);
     return 0;
   }
 
-  if (version) {
+  if (values['version'] === true) {
     console.log(await readPackageVersion());
     return 0;
   }

--- a/packages/cli/src/node-runtime.d.ts
+++ b/packages/cli/src/node-runtime.d.ts
@@ -37,12 +37,12 @@ declare module 'node:util' {
       string,
       {
         short?: string;
-        type: 'boolean';
+        type: 'boolean' | 'string';
       }
     >;
     allowPositionals?: boolean;
   }): {
-    values: Record<string, boolean | undefined>;
+    values: Record<string, boolean | string | undefined>;
     positionals: string[];
   };
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -5,5 +5,6 @@
     "rootDir": "src",
     "types": []
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    projects: ['packages/core', 'packages/web', 'packages/cli'],
+    coverage: {
+      provider: 'v8',
+    },
   },
 });


### PR DESCRIPTION
Closes #129 · Refs roadmap #122 · Depends on #128 (merged), #123 (merged)

Implements wave-7's headless batch runner: simulate N games of
all-random bots from `seedStart..seedStart+N-1` and emit one
`GameOutcome` per game.

## Summary

- **\`packages/cli/src/batch.ts\` (new)** — \`runBatch({ playerCount,
  seedStart, gameCount, ... })\` returns
  \`{ outcomes: GameOutcome[] }\` with \`seed\`, \`winner\`, \`rounds\`,
  \`survivingTeams\`, \`totalDamageDealt\`, \`graveyardSize\` per game.
  Strategies use \`randomStrategy(strategySeed + teamId)\` and the
  inner per-round loop wraps \`runRound\` directly so battle damage
  can be aggregated from \`RoundOutput.battleResults\` (which
  \`runUntilGameOver\` does not expose).
- **Movement-choice normalisation** — the \`InputProvider\` runs on
  round-start state, but movement resolves *after* battle has
  consumed cards. To avoid the empty-hand \`RangeError\` in
  \`resolveMovementChoices\`, every movement choice is demoted to
  \`emergency-draw\`; its fallback uses \`team.cards[0]\` when the
  hand is non-empty or draws fresh cards when empty. This trades a
  little tactical fidelity for deterministic batch runs.
- **CLI integration** — \`oneiron batch\` subcommand dispatched
  before option parsing, with flags \`--player-count\`, \`--games\`,
  \`--seed-start\`, \`--max-rounds\`, \`--strategy-seed\`. Emits the
  batch output as a single JSON line; missing or non-integer flags
  exit with code 1 and an explanatory \`stderr\` message.
- **Test wiring** — \`packages/cli/vitest.config.ts\` added; root
  \`vitest.config.ts\` picks up \`packages/cli\` as a Vitest project.
  \`packages/cli/tsconfig.json\` excludes \`*.test.ts\` so the test
  files' \`vitest\` import does not drag Vite's types into the
  declaration-only \`tsc --noEmit\` pass.
- **\`node-runtime.d.ts\`** — \`parseArgs\` typing extended to allow
  \`type: 'string'\` options alongside booleans (no new dependency).

## Out of scope

The published \`bin/oneiron.js\` is **not** updated in this PR.
Wiring batch through the standalone bin needs a compiled drop of
\`packages/cli\` (mirroring what #135 did for \`@kurone-kito/oneiron-core\`)
and is intentionally left for a follow-up.

## Test plan

- [x] \`pnpm run test\` — 248 tests pass (13 new for CLI)
  - \`batch.test.ts\` (6): outcome shape, sequential seeds,
    determinism, max-rounds cap, winner-in-survivors, strategy-seed
    sensitivity.
  - \`cli.test.ts\` (7): success JSON, JSON identity across reruns,
    missing \`--player-count\`, missing \`--games\`, non-integer flag,
    plus the original help / ready behaviours.
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean
- [x] Smoke test:
      \`pnpm --filter @kurone-kito/oneiron-cli exec tsx src/cli.ts batch --player-count 4 --games 2 --seed-start 1\`
      prints valid JSON with two outcome records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `batch` subcommand to the CLI for running multiple deterministic games with configurable parameters including player count, game count, starting seed, maximum rounds per game, and strategy seed. Results are output as JSON with outcome details for each game.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->