### PR TITLE
feat(web): auto-play, state history, and replay scrubbing

### DIFF
--- a/packages/web/src/screens/GameplayScreen.test.tsx
+++ b/packages/web/src/screens/GameplayScreen.test.tsx
@@ -12,7 +12,7 @@ import {
   type TeamState,
 } from '@kurone-kito/oneiron-core';
 import { cleanup, fireEvent, render, screen } from '@solidjs/testing-library';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GameplayScreen } from './GameplayScreen.tsx';
 
 afterEach(cleanup);
@@ -148,5 +148,97 @@ describe('GameplayScreen', () => {
     render(() => <GameplayScreen initialState={initial} config={config} />);
     const teamArticle = screen.queryAllByLabelText(/^Team \d+$/);
     expect(teamArticle.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the initial state visible for all-bot sessions until Play', () => {
+    const initial = setupGame({ playerCount: 4, seed: 7 }, DEFAULT_CONFIG);
+    const config = botConfigFor(initial, 50);
+    render(() => <GameplayScreen initialState={initial} config={config} />);
+    // No auto-advance: history holds exactly the initial frame.
+    const historySection = screen.getByLabelText('State history');
+    expect(historySection.textContent ?? '').toMatch(/Frame\s*1\s*\/\s*1/);
+    expect(screen.getByRole('button', { name: 'Play' })).toBeTruthy();
+  });
+
+  it('auto-play advances rounds and pauses when the user clicks Pause', async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = setupGame({ playerCount: 4, seed: 11 }, DEFAULT_CONFIG);
+      const config = botConfigFor(initial, 60);
+      render(() => <GameplayScreen initialState={initial} config={config} />);
+      const play = screen.getByRole('button', { name: 'Play' });
+      fireEvent.click(play);
+      // Default delay is 200ms; flush a few ticks worth.
+      await vi.advanceTimersByTimeAsync(1000);
+      const pause = screen.getByRole('button', { name: 'Pause' });
+      fireEvent.click(pause);
+      // After pausing, more than one frame should have accumulated.
+      const historySection = screen.getByLabelText('State history');
+      expect(historySection.textContent ?? '').not.toMatch(
+        /Frame\s*1\s*\/\s*1/,
+      );
+      expect(screen.getByRole('button', { name: 'Play' })).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('history navigation moves between frames and re-enables live mode', async () => {
+    vi.useFakeTimers();
+    try {
+      const initial = setupGame({ playerCount: 4, seed: 13 }, DEFAULT_CONFIG);
+      const config = botConfigFor(initial, 80);
+      render(() => <GameplayScreen initialState={initial} config={config} />);
+      fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+      await vi.advanceTimersByTimeAsync(800);
+      fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+
+      const prev = screen.getByRole('button', { name: /Previous/ });
+      fireEvent.click(prev);
+      expect(screen.getByLabelText('History view banner')).toBeTruthy();
+
+      const jumpToLive = screen.getByRole('button', { name: 'Jump to live' });
+      fireEvent.click(jumpToLive);
+      expect(screen.queryByLabelText('History view banner')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('hides phase input panels when viewing a historical frame', () => {
+    const teamA = makeTeam({
+      id: 1 as TeamId,
+      position: { x: 'fire', y: 'water' },
+      life: 3,
+      cards: [wood1],
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as TeamId,
+      position: { x: 'fire', y: 'water' },
+      life: 3,
+      cards: [wood4],
+      gridCards: [wood1, wood4],
+    });
+    const initial = stateWith([teamA, teamB]);
+    const controls = new Map<TeamId, TeamControl>([
+      [1 as TeamId, { type: 'human' }],
+      [2 as TeamId, { type: 'human' }],
+    ]);
+    render(() => (
+      <GameplayScreen
+        initialState={initial}
+        config={{ controls, gameConfig: DEFAULT_CONFIG }}
+      />
+    ));
+    expect(screen.getByLabelText(/phase input — battle/i)).toBeTruthy();
+    // Step back into history — submit a turn first so there's a
+    // prior frame to revisit.
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Submit battle plays' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Previous/ }));
+    expect(screen.queryByLabelText(/phase input — battle/i)).toBeNull();
+    expect(screen.getByLabelText('History view banner')).toBeTruthy();
   });
 });

--- a/packages/web/src/screens/GameplayScreen.tsx
+++ b/packages/web/src/screens/GameplayScreen.tsx
@@ -8,6 +8,7 @@ import type {
   RevivalAction,
   RoundState,
   SessionConfig,
+  TeamControl,
   TeamId,
   TeamMove,
   TeamState,
@@ -18,7 +19,16 @@ import {
   isGameOver,
   winner as winnerOf,
 } from '@kurone-kito/oneiron-core';
-import { createMemo, createSignal, For, onMount, Show } from 'solid-js';
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  on,
+  onCleanup,
+  onMount,
+  Show,
+} from 'solid-js';
 import { CardFace } from '../components/CardFace.tsx';
 import { GameGrid } from '../components/Grid.tsx';
 import { Hand } from '../components/Hand.tsx';
@@ -35,6 +45,10 @@ const REVIVAL_ACTIONS: readonly RevivalAction['type'][] = [
   'charge-life',
   'charge-cards',
 ];
+
+const MIN_AUTOPLAY_DELAY_MS = 0;
+const MAX_AUTOPLAY_DELAY_MS = 2000;
+const DEFAULT_AUTOPLAY_DELAY_MS = 200;
 
 function listLivingTeams(state: RoundState): TeamState[] {
   const teams: TeamState[] = [];
@@ -62,30 +76,53 @@ function describeCard(card: Card): string {
   return card.kind === 'joker' ? 'Joker' : `${card.element} ${card.value}`;
 }
 
-/**
- * Encodes a card as a stable string key so radio / option groups can
- * round-trip selection through the DOM without aliasing duplicate
- * entries.
- */
 function cardKey(card: Card, idx: number): string {
   return card.kind === 'joker'
     ? `joker@${idx}`
     : `${card.element}-${card.value}@${idx}`;
 }
 
+function controlsAreAllBot(
+  controls: ReadonlyMap<TeamId, TeamControl>,
+): boolean {
+  if (controls.size === 0) return false;
+  for (const control of controls.values()) {
+    if (control.type !== 'bot') return false;
+  }
+  return true;
+}
+
 export function GameplayScreen(props: GameplayScreenProps) {
   let session = createSession(props.initialState, props.config);
 
-  const [state, setState] = createSignal<RoundState>(props.initialState);
+  const [history, setHistory] = createSignal<readonly RoundState[]>([
+    props.initialState,
+  ]);
+  const [viewIndex, setViewIndex] = createSignal(0);
   const [pending, setPending] = createSignal<HumanInputRequest | null>(null);
   // The session does not currently surface phase-by-phase log entries;
   // the TurnLog renders an empty list until a logging hook is added in
-  // a follow-up issue. Keeping the signal in place so the JSX wiring is
-  // ready for that future work.
+  // a follow-up issue.
   const [log] = createSignal<readonly LogEntry[]>([]);
   const [over, setOver] = createSignal(false);
 
-  // Form state for the awaiting phase — keyed by team id.
+  const [autoPlayActive, setAutoPlayActive] = createSignal(false);
+  const [autoPlayDelayMs, setAutoPlayDelayMs] = createSignal(
+    DEFAULT_AUTOPLAY_DELAY_MS,
+  );
+
+  const headState = createMemo(() => {
+    const frames = history();
+    return frames[frames.length - 1] as RoundState;
+  });
+  const displayedState = createMemo(
+    () => history()[viewIndex()] ?? headState(),
+  );
+  const isViewingHistory = createMemo(
+    () => viewIndex() !== history().length - 1,
+  );
+  const isAllBot = createMemo(() => controlsAreAllBot(props.config.controls));
+
   const [battleSelections, setBattleSelections] = createSignal<
     ReadonlyMap<TeamId, string | null>
   >(new Map());
@@ -95,6 +132,11 @@ export function GameplayScreen(props: GameplayScreenProps) {
   const [revivalSelections, setRevivalSelections] = createSignal<
     ReadonlyMap<TeamId, RevivalAction['type']>
   >(new Map());
+
+  function pushState(next: RoundState): void {
+    setHistory((frames) => [...frames, next]);
+    setViewIndex(history().length - 1);
+  }
 
   function resetFormsFor(request: HumanInputRequest | null): void {
     if (request === null) {
@@ -106,7 +148,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
     switch (request.phase) {
       case 'battle': {
         const next = new Map<TeamId, string | null>();
-        for (const id of request.humanTeams) next.set(id, null); // null = forfeit
+        for (const id of request.humanTeams) next.set(id, null);
         setBattleSelections(next);
         break;
       }
@@ -116,7 +158,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
           { cardKey: string; facing: Facing; slot: 0 | 1 }
         >();
         for (const id of request.humanTeams) {
-          const team = findTeam(state(), id);
+          const team = findTeam(headState(), id);
           const firstCard = team?.cards[0];
           next.set(id, {
             cardKey: firstCard ? cardKey(firstCard, 0) : '',
@@ -136,48 +178,123 @@ export function GameplayScreen(props: GameplayScreenProps) {
     }
   }
 
-  /** Drives the session until it either awaits input or the game ends. */
-  function drive(humanInputs?: HumanInputs): void {
-    let iterations = 0;
-    let inputs = humanInputs;
-    while (iterations < 200) {
-      iterations += 1;
-      const result = session.step(inputs);
-      inputs = undefined;
-      setState(result.state);
+  /**
+   * Drives the session forward. Pushes a history frame after every
+   * `session.step` call so the replay UI can scrub through past
+   * states. Stops at the first awaiting request, at game-over, or
+   * once the round completes (so the auto-play loop can insert a
+   * delay between rounds).
+   *
+   * Returns the terminal status so callers know whether to keep
+   * ticking ('round-done') or wait for input ('awaiting' / 'game-over').
+   */
+  function drive(
+    humanInputs?: HumanInputs,
+  ): 'awaiting' | 'round-done' | 'game-over' {
+    const result = session.step(humanInputs);
+    pushState(result.state);
 
-      if (result.status === 'awaiting') {
-        setPending(result.request);
-        resetFormsFor(result.request);
-        return;
-      }
-      // status === 'done'
-      setPending(null);
-      if (isGameOver(result.state)) {
-        setOver(true);
-        return;
-      }
-      // Start next round with a fresh session over the same controls.
-      session = createSession(result.state, props.config);
+    if (result.status === 'awaiting') {
+      setPending(result.request);
+      resetFormsFor(result.request);
+      return 'awaiting';
     }
-    // Safety net — should not be reached in practice.
-    console.error('[GameplayScreen] drive() bailed out after 200 iterations');
+    setPending(null);
+    if (isGameOver(result.state)) {
+      setOver(true);
+      return 'game-over';
+    }
+    session = createSession(result.state, props.config);
+    return 'round-done';
   }
 
   onMount(() => {
+    // For all-bot configurations, leave the initial state visible
+    // and wait for the user to press Play. Mixed-control sessions
+    // advance until the first awaiting request so the matching
+    // input panel appears.
+    if (isAllBot()) return;
     drive();
   });
 
-  const livingTeams = createMemo(() => listLivingTeams(state()));
+  let autoPlayTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function cancelAutoPlayTimer(): void {
+    if (autoPlayTimer !== null) {
+      clearTimeout(autoPlayTimer);
+      autoPlayTimer = null;
+    }
+  }
+
+  function tickAutoPlay(): void {
+    if (!autoPlayActive() || over() || pending() !== null) {
+      setAutoPlayActive(false);
+      return;
+    }
+    const status = drive();
+    if (status === 'game-over' || status === 'awaiting') {
+      setAutoPlayActive(false);
+      return;
+    }
+    scheduleAutoPlay();
+  }
+
+  function scheduleAutoPlay(): void {
+    cancelAutoPlayTimer();
+    autoPlayTimer = setTimeout(tickAutoPlay, autoPlayDelayMs());
+  }
+
+  // React to autoPlayActive transitions: start ticking when turned
+  // on; cancel any pending timer when turned off (regardless of
+  // whether the user paused or a terminal state ended the loop).
+  createEffect(
+    on(autoPlayActive, (active) => {
+      if (active) {
+        scheduleAutoPlay();
+      } else {
+        cancelAutoPlayTimer();
+      }
+    }),
+  );
+
+  onCleanup(cancelAutoPlayTimer);
+
+  function toggleAutoPlay(): void {
+    if (autoPlayActive()) {
+      setAutoPlayActive(false);
+      return;
+    }
+    if (over() || pending() !== null) return;
+    // Jump back to live before resuming so we don't fork off a
+    // history branch.
+    setViewIndex(history().length - 1);
+    setAutoPlayActive(true);
+  }
+
+  function goPrev(): void {
+    setViewIndex((idx) => Math.max(0, idx - 1));
+  }
+  function goNext(): void {
+    setViewIndex((idx) => Math.min(history().length - 1, idx + 1));
+  }
+  function goLive(): void {
+    setViewIndex(history().length - 1);
+  }
+  function jumpToFrame(target: number): void {
+    setViewIndex(Math.min(Math.max(0, target), history().length - 1));
+  }
+
+  const livingTeams = createMemo(() => listLivingTeams(displayedState()));
 
   function submitBattle(): void {
+    if (isViewingHistory()) return;
     const req = pending();
     if (req?.phase !== 'battle') return;
     const plays = new Map<TeamId, BattlePlay>();
     const selections = battleSelections();
     for (const id of req.humanTeams) {
       const key = selections.get(id) ?? null;
-      const team = findTeam(state(), id);
+      const team = findTeam(headState(), id);
       const card =
         key === null || team === undefined
           ? null
@@ -188,13 +305,14 @@ export function GameplayScreen(props: GameplayScreenProps) {
   }
 
   function submitMovement(): void {
+    if (isViewingHistory()) return;
     const req = pending();
     if (req?.phase !== 'movement') return;
     const moves = new Map<TeamId, TeamMove>();
     const selections = moveSelections();
     for (const id of req.humanTeams) {
       const sel = selections.get(id);
-      const team = findTeam(state(), id);
+      const team = findTeam(headState(), id);
       if (!sel || team === undefined) continue;
       const card = team.cards.find((c, i) => cardKey(c, i) === sel.cardKey);
       if (card === undefined) continue;
@@ -209,6 +327,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
   }
 
   function submitRevival(): void {
+    if (isViewingHistory()) return;
     const req = pending();
     if (req?.phase !== 'revival') return;
     const actions = new Map<TeamId, RevivalAction>();
@@ -225,20 +344,87 @@ export function GameplayScreen(props: GameplayScreenProps) {
       <header class="gameplay__header">
         <h1>Game session</h1>
         <p>
-          Round <strong>{state().round}</strong>, phase{' '}
-          <strong>{state().phase}</strong>
+          Round <strong>{displayedState().round}</strong>, phase{' '}
+          <strong>{displayedState().phase}</strong>
         </p>
         <p>
-          Deck: <strong>{state().deck?.length ?? 0}</strong> · Graveyard:{' '}
-          <strong>{state().graveyard?.length ?? 0}</strong> · Forbidden cells:{' '}
-          <strong>{state().forbiddenCells.length}</strong>
+          Deck: <strong>{displayedState().deck?.length ?? 0}</strong> ·
+          Graveyard: <strong>{displayedState().graveyard?.length ?? 0}</strong>{' '}
+          · Forbidden cells:{' '}
+          <strong>{displayedState().forbiddenCells.length}</strong>
         </p>
       </header>
 
+      <section class="gameplay__history" aria-label="State history">
+        <h2>History</h2>
+        <p>
+          Frame <strong>{viewIndex() + 1}</strong> / {history().length}
+          <Show when={isViewingHistory()}>
+            {' '}
+            — <em>viewing history</em>
+          </Show>
+        </p>
+        <button type="button" onClick={goPrev} disabled={viewIndex() === 0}>
+          ← Previous
+        </button>
+        <button
+          type="button"
+          onClick={goNext}
+          disabled={viewIndex() >= history().length - 1}
+        >
+          Next →
+        </button>
+        <button
+          type="button"
+          onClick={goLive}
+          disabled={!isViewingHistory()}
+          aria-label="Jump to live"
+        >
+          Jump to live
+        </button>
+        <label>
+          Frame:
+          <input
+            type="range"
+            min="0"
+            max={history().length - 1}
+            value={viewIndex()}
+            onInput={(e) => jumpToFrame(Number(e.currentTarget.value))}
+            aria-label="History timeline"
+          />
+        </label>
+      </section>
+
+      <Show when={isAllBot()}>
+        <section class="gameplay__autoplay" aria-label="Auto-play controls">
+          <h2>Auto-play</h2>
+          <button
+            type="button"
+            onClick={toggleAutoPlay}
+            disabled={over() || isViewingHistory()}
+          >
+            {autoPlayActive() ? 'Pause' : 'Play'}
+          </button>
+          <label>
+            Delay (ms):
+            <input
+              type="range"
+              min={MIN_AUTOPLAY_DELAY_MS}
+              max={MAX_AUTOPLAY_DELAY_MS}
+              step="50"
+              value={autoPlayDelayMs()}
+              onInput={(e) => setAutoPlayDelayMs(Number(e.currentTarget.value))}
+              aria-label="Auto-play delay milliseconds"
+            />
+            <output>{autoPlayDelayMs()}</output>
+          </label>
+        </section>
+      </Show>
+
       <GameGrid
-        grid={state().grid}
-        forbiddenCells={[...state().forbiddenCells]}
-        currentPhase={state().phase}
+        grid={displayedState().grid}
+        forbiddenCells={[...displayedState().forbiddenCells]}
+        currentPhase={displayedState().phase}
       />
 
       <section aria-label="Surviving teams">
@@ -273,7 +459,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
         </For>
       </section>
 
-      <Show when={pending() !== null && !over()}>
+      <Show when={pending() !== null && !over() && !isViewingHistory()}>
         <section
           class="gameplay__input"
           aria-label={`Phase input — ${pending()?.phase}`}
@@ -285,7 +471,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
               each={(pending() as { humanTeams: readonly TeamId[] }).humanTeams}
             >
               {(teamId) => {
-                const team = findTeam(state(), teamId);
+                const team = findTeam(headState(), teamId);
                 return (
                   <fieldset>
                     <legend>Team {teamId} — battle play</legend>
@@ -343,7 +529,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
               each={(pending() as { humanTeams: readonly TeamId[] }).humanTeams}
             >
               {(teamId) => {
-                const team = findTeam(state(), teamId);
+                const team = findTeam(headState(), teamId);
                 const cards = team?.cards ?? [];
                 return (
                   <fieldset>
@@ -462,15 +648,26 @@ export function GameplayScreen(props: GameplayScreenProps) {
         </section>
       </Show>
 
+      <Show when={isViewingHistory()}>
+        <section
+          class="gameplay__history-banner"
+          aria-label="History view banner"
+        >
+          <p>
+            <em>Viewing history. Jump to live to continue making inputs.</em>
+          </p>
+        </section>
+      </Show>
+
       <Show when={over()}>
         <section aria-label="Game over" class="gameplay__game-over">
           <h2>Game over</h2>
           <Show
-            when={winnerOf(state()) !== null}
+            when={winnerOf(headState()) !== null}
             fallback={<p>No winner — all teams eliminated or stalemate.</p>}
           >
             <p>
-              Winner: <strong>Team {winnerOf(state())}</strong>
+              Winner: <strong>Team {winnerOf(headState())}</strong>
             </p>
           </Show>
         </section>


### PR DESCRIPTION
Closes #127 · Refs roadmap #121 · Depends on #124 (merged), #126 (merged)

Extends \`GameplayScreen\` with a state-history store and the two
controls the maintainer needs to drive bot-only games and revisit
past states without forking the live timeline.

## Summary

- **State history** — every \`session.step\` result is pushed into a
  \`history: readonly RoundState[]\` signal, and \`viewIndex\`
  defaults to the head. \`displayedState\` (used by the grid,
  header, team list) reads from \`history[viewIndex]\`, while
  \`headState\` keeps pointing at the live frame for input forms
  and game-over checks.
- **Navigation controls** — \`← Previous\`, \`Next →\`,
  \`Jump to live\`, and a range slider scrub through history. A
  banner explains the scrub mode and the input panel hides while
  viewing a non-head frame, so submissions can't fork the state
  tree.
- **Auto-play** — Play / Pause button shown when all teams are
  bot-controlled. The driver advances one round per tick using
  \`setTimeout\` with a configurable delay (0–2000 ms slider,
  default 200 ms). The effect tears the timer down whenever
  auto-play turns off, and \`onCleanup\` cancels any pending tick
  on unmount. Auto-play also halts on game-over, when a frame is
  being scrubbed, or when an awaiting request appears.
- **\`drive\` refactor** — was a synchronous loop that advanced rounds
  until awaiting / game-over. It is now one-shot per call (one
  \`session.step\`), returning \`'awaiting'\` / \`'round-done'\` /
  \`'game-over'\` so the auto-play tick can drive it at a controlled
  cadence and so each round boundary is one history entry.
- **Mount behaviour** — all-bot configs no longer auto-advance on
  mount; the initial state is visible and the user presses Play
  to start. Mixed-control configs still drive forward to the
  first awaiting input.

## Test plan

- [x] \`pnpm run test\` — 239 tests pass (4 new in
      \`GameplayScreen.test.tsx\`)
  - all-bot idle-on-mount path
  - auto-play tick + Pause (uses \`vi.useFakeTimers\`)
  - prev → jump-to-live history navigation
  - input-panel hide while viewing a historical frame
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests for GameplayScreen covering auto-play, history navigation, and UI state management.

* **New Features**
  * Added game history and replay functionality with timeline controls (Previous, Next, Jump to live).
  * Auto-play feature with configurable delays.
  * History-view banner and disabled input panels when viewing past frames.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->