### PR TITLE
feat(cli): batch outcome metrics + report output (JSON / CSV / Markdown)

### DIFF
--- a/packages/cli/src/batch.ts
+++ b/packages/cli/src/batch.ts
@@ -51,6 +51,12 @@ export type GameOutcome = {
   readonly survivingTeams: readonly TeamId[];
   readonly totalDamageDealt: number;
   readonly graveyardSize: number;
+  /**
+   * Teams that started the game with a single player (i.e. were
+   * "solo teams" after setup). Used by the report layer to compute
+   * solo-team win rates without a separate setup snapshot.
+   */
+  readonly soloTeams: readonly TeamId[];
 };
 
 export type BatchOutput = {
@@ -143,6 +149,9 @@ export function runBatch(input: BatchInput): BatchOutput {
     );
     const strategies = buildStrategies(initial, strategySeed);
     const inputProvider = makeInputProvider(strategies);
+    const soloTeams = listAllTeams(initial)
+      .filter((team) => team.players.length === 1)
+      .map((team) => team.teamNumber);
 
     let current = initial;
     let rounds = 0;
@@ -169,6 +178,7 @@ export function runBatch(input: BatchInput): BatchOutput {
       survivingTeams,
       totalDamageDealt,
       graveyardSize: current.graveyard?.length ?? 0,
+      soloTeams,
     });
   }
 

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { runCli } from './cli.ts';
 
@@ -34,7 +37,7 @@ describe('runCli', () => {
   });
 
   describe('batch subcommand', () => {
-    it('prints JSON with one outcome per game on success', async () => {
+    it('prints JSON with summary and outcomes on success', async () => {
       const code = await runCli([
         'batch',
         '--player-count',
@@ -48,9 +51,11 @@ describe('runCli', () => {
       expect(stdout).toHaveLength(1);
       const parsed = JSON.parse(stdout[0] ?? '') as {
         outcomes: readonly { seed: number }[];
+        summary: { games: number };
       };
       expect(parsed.outcomes).toHaveLength(3);
       expect(parsed.outcomes.map((o) => o.seed)).toEqual([1, 2, 3]);
+      expect(parsed.summary.games).toBe(3);
     });
 
     it('produces identical JSON across runs with the same flags', async () => {
@@ -97,6 +102,83 @@ describe('runCli', () => {
       ]);
       expect(code).toBe(1);
       expect(stderr.join('\n')).toContain('Invalid integer');
+    });
+
+    it('emits CSV with --format csv', async () => {
+      const code = await runCli([
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        '2',
+        '--seed-start',
+        '1',
+        '--format',
+        'csv',
+      ]);
+      expect(code).toBe(0);
+      const out = stdout[0] ?? '';
+      expect(out.split('\n')[0]).toBe(
+        'seed,winner,rounds,survivingTeams,totalDamageDealt,graveyardSize,soloTeams',
+      );
+      expect(out.split('\n')).toHaveLength(3);
+    });
+
+    it('emits Markdown with --format markdown', async () => {
+      const code = await runCli([
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        '2',
+        '--seed-start',
+        '1',
+        '--format',
+        'markdown',
+      ]);
+      expect(code).toBe(0);
+      const out = stdout[0] ?? '';
+      expect(out).toContain('# Batch summary');
+      expect(out).toContain('## Win rates by team number');
+    });
+
+    it('rejects unknown --format values', async () => {
+      const code = await runCli([
+        'batch',
+        '--player-count',
+        '4',
+        '--games',
+        '1',
+        '--format',
+        'xml',
+      ]);
+      expect(code).toBe(1);
+      expect(stderr.join('\n')).toContain('--format');
+    });
+
+    it('writes to --output path instead of stdout', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'oneiron-batch-'));
+      const file = join(dir, 'report.json');
+      try {
+        const code = await runCli([
+          'batch',
+          '--player-count',
+          '4',
+          '--games',
+          '2',
+          '--seed-start',
+          '1',
+          '--output',
+          file,
+        ]);
+        expect(code).toBe(0);
+        expect(stdout).toHaveLength(0);
+        const contents = await readFile(file, 'utf8');
+        const parsed = JSON.parse(contents) as { outcomes: unknown[] };
+        expect(parsed.outcomes).toHaveLength(2);
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env -S node --experimental-strip-types
 
-import { readFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 import { runBatch } from './batch.ts';
+import { formatCsv, formatJson, formatMarkdown, summarise } from './report.ts';
 
 const HELP_TEXT = `oneiron - headless Dream Duels simulator
 
@@ -19,11 +20,13 @@ Subcommands:
   batch          Run N games and print outcome JSON to stdout
 
 Batch options:
-  --player-count <n>    Number of teams (required)
-  --games <n>           Number of games to run (required)
-  --seed-start <n>      Seed for the first game (default 0)
-  --max-rounds <n>      Max rounds per game (default 50)
-  --strategy-seed <n>   Base seed for bot strategies (default 0)`;
+  --player-count <n>      Number of teams (required)
+  --games <n>             Number of games to run (required)
+  --seed-start <n>        Seed for the first game (default 0)
+  --max-rounds <n>        Max rounds per game (default 50)
+  --strategy-seed <n>     Base seed for bot strategies (default 0)
+  --format <fmt>          Output format: json (default), csv, markdown
+  --output <path>         Write to <path> instead of stdout`;
 
 const READY_TEXT = 'oneiron-cli ready';
 const FALLBACK_VERSION = '0.0.0';
@@ -50,7 +53,19 @@ const batchOptions = {
   'seed-start': { type: 'string' },
   'max-rounds': { type: 'string' },
   'strategy-seed': { type: 'string' },
+  format: { type: 'string' },
+  output: { type: 'string' },
 } as const;
+
+type BatchFormat = 'json' | 'csv' | 'markdown';
+
+function parseFormat(raw: string | undefined): BatchFormat {
+  if (raw === undefined) return 'json';
+  if (raw === 'json' || raw === 'csv' || raw === 'markdown') return raw;
+  throw new Error(
+    `Invalid --format value '${raw}'. Expected json, csv, or markdown.`,
+  );
+}
 
 const readErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
@@ -111,7 +126,7 @@ const parseOptionalInt = (
   return Number.parseInt(raw, 10);
 };
 
-const runBatchCommand = (argv: readonly string[]): number => {
+const runBatchCommand = async (argv: readonly string[]): Promise<number> => {
   let values: {
     readonly [K in keyof typeof batchOptions]?: string;
   };
@@ -148,14 +163,37 @@ const runBatchCommand = (argv: readonly string[]): number => {
       values['strategy-seed'],
       DEFAULT_BATCH_STRATEGY_SEED,
     );
-    const output = runBatch({
+    const format = parseFormat(values.format);
+    const outputPath = values.output;
+
+    const result = runBatch({
       playerCount,
       gameCount,
       seedStart,
       maxRoundsPerGame,
       strategySeed,
     });
-    console.log(JSON.stringify(output));
+    const summary = summarise(result.outcomes);
+    let rendered: string;
+    switch (format) {
+      case 'csv':
+        rendered = formatCsv(result.outcomes);
+        break;
+      case 'markdown':
+        rendered = formatMarkdown(summary);
+        break;
+      default:
+        rendered = JSON.stringify({
+          summary: JSON.parse(formatJson(summary)),
+          outcomes: result.outcomes,
+        });
+        break;
+    }
+    if (outputPath !== undefined) {
+      await writeFile(outputPath, rendered, 'utf8');
+    } else {
+      console.log(rendered);
+    }
     return 0;
   } catch (error) {
     console.error(readErrorMessage(error));
@@ -167,7 +205,7 @@ export const runCli = async (
   argv: readonly string[] = process.argv.slice(2),
 ): Promise<number> => {
   if (argv[0] === 'batch') {
-    return runBatchCommand(argv.slice(1));
+    return await runBatchCommand(argv.slice(1));
   }
 
   let values: Record<string, boolean | string | undefined>;

--- a/packages/cli/src/node-runtime.d.ts
+++ b/packages/cli/src/node-runtime.d.ts
@@ -28,6 +28,11 @@ declare module 'node:fs/promises' {
     path: string | URL,
     encoding: string,
   ): Promise<string>;
+  export function writeFile(
+    path: string | URL,
+    data: string,
+    encoding: string,
+  ): Promise<void>;
 }
 
 declare module 'node:util' {

--- a/packages/cli/src/report.test.ts
+++ b/packages/cli/src/report.test.ts
@@ -1,0 +1,139 @@
+import type { TeamId } from '@kurone-kito/oneiron-core';
+import { describe, expect, it } from 'vitest';
+import type { GameOutcome } from './batch.ts';
+import { formatCsv, formatJson, formatMarkdown, summarise } from './report.ts';
+
+function outcome(overrides: Partial<GameOutcome> = {}): GameOutcome {
+  return {
+    seed: overrides.seed ?? 0,
+    winner: overrides.winner ?? null,
+    rounds: overrides.rounds ?? 1,
+    survivingTeams: overrides.survivingTeams ?? [],
+    totalDamageDealt: overrides.totalDamageDealt ?? 0,
+    graveyardSize: overrides.graveyardSize ?? 0,
+    soloTeams: overrides.soloTeams ?? [],
+  };
+}
+
+describe('summarise', () => {
+  it('counts wins, draws, and rounds correctly', () => {
+    const outcomes = [
+      outcome({ seed: 1, winner: 1 as TeamId, rounds: 5 }),
+      outcome({ seed: 2, winner: 2 as TeamId, rounds: 7 }),
+      outcome({ seed: 3, winner: 1 as TeamId, rounds: 10 }),
+      outcome({ seed: 4, winner: null, rounds: 50 }),
+    ];
+    const summary = summarise(outcomes);
+    expect(summary.games).toBe(4);
+    expect(summary.winsByTeam.get(1 as TeamId)).toBe(2);
+    expect(summary.winsByTeam.get(2 as TeamId)).toBe(1);
+    expect(summary.drawCount).toBe(1);
+    expect(summary.minRounds).toBe(5);
+    expect(summary.maxRounds).toBe(50);
+    expect(summary.avgRounds).toBeCloseTo((5 + 7 + 10 + 50) / 4, 5);
+  });
+
+  it('returns null soloTeamWinRate when no solo team appears', () => {
+    const outcomes = [
+      outcome({ winner: 1 as TeamId }),
+      outcome({ winner: 2 as TeamId }),
+    ];
+    const summary = summarise(outcomes);
+    expect(summary.soloTeamWinRate).toBeNull();
+  });
+
+  it('computes soloTeamWinRate when solo teams exist', () => {
+    const outcomes = [
+      outcome({ winner: 1 as TeamId, soloTeams: [1 as TeamId] }),
+      outcome({ winner: 2 as TeamId, soloTeams: [1 as TeamId] }),
+      outcome({ winner: null, soloTeams: [3 as TeamId] }),
+    ];
+    const summary = summarise(outcomes);
+    // 3 games had solo teams; only the first had a solo winner.
+    expect(summary.soloTeamWinRate).toBeCloseTo(1 / 3, 5);
+  });
+
+  it('averages graveyard size and total damage', () => {
+    const outcomes = [
+      outcome({ graveyardSize: 10, totalDamageDealt: 5 }),
+      outcome({ graveyardSize: 20, totalDamageDealt: 15 }),
+    ];
+    const summary = summarise(outcomes);
+    expect(summary.avgGraveyardSize).toBe(15);
+    expect(summary.avgTotalDamage).toBe(10);
+  });
+
+  it('handles an empty outcomes list gracefully', () => {
+    const summary = summarise([]);
+    expect(summary.games).toBe(0);
+    expect(summary.drawCount).toBe(0);
+    expect(summary.minRounds).toBe(0);
+    expect(summary.maxRounds).toBe(0);
+    expect(summary.avgRounds).toBe(0);
+    expect(summary.soloTeamWinRate).toBeNull();
+  });
+});
+
+describe('formatJson', () => {
+  it('emits a JSON document that round-trips through JSON.parse', () => {
+    const summary = summarise([
+      outcome({ winner: 1 as TeamId, rounds: 4 }),
+      outcome({ winner: 1 as TeamId, rounds: 6 }),
+    ]);
+    const json = formatJson(summary);
+    const parsed = JSON.parse(json) as {
+      games: number;
+      winsByTeam: Record<string, number>;
+    };
+    expect(parsed.games).toBe(2);
+    expect(parsed.winsByTeam['1']).toBe(2);
+  });
+});
+
+describe('formatCsv', () => {
+  it('emits a header row and one line per outcome', () => {
+    const outcomes = [
+      outcome({
+        seed: 1,
+        winner: 1 as TeamId,
+        rounds: 5,
+        survivingTeams: [1 as TeamId],
+        totalDamageDealt: 3,
+        graveyardSize: 12,
+        soloTeams: [1 as TeamId, 2 as TeamId],
+      }),
+      outcome({ seed: 2, winner: null, rounds: 50 }),
+    ];
+    const csv = formatCsv(outcomes);
+    const lines = csv.split('\n');
+    expect(lines[0]).toBe(
+      'seed,winner,rounds,survivingTeams,totalDamageDealt,graveyardSize,soloTeams',
+    );
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe('1,1,5,1,3,12,1 2');
+    expect(lines[2]).toBe('2,,50,,0,0,');
+  });
+});
+
+describe('formatMarkdown', () => {
+  it('contains the required sections and renders win-rate rows', () => {
+    const summary = summarise([
+      outcome({ winner: 1 as TeamId, rounds: 5, soloTeams: [1 as TeamId] }),
+      outcome({ winner: 2 as TeamId, rounds: 10, soloTeams: [3 as TeamId] }),
+      outcome({ winner: null, rounds: 50 }),
+    ]);
+    const md = formatMarkdown(summary);
+    expect(md).toContain('# Batch summary');
+    expect(md).toContain('## Win rates by team number');
+    expect(md).toContain('## Solo team win rate');
+    expect(md).toContain('## Card economy');
+    expect(md).toMatch(/\| 1 \| 1 \| 33\.33% \|/);
+    expect(md).toMatch(/\| 2 \| 1 \| 33\.33% \|/);
+  });
+
+  it('notes the absence of solo teams when none are present', () => {
+    const summary = summarise([outcome({ winner: 1 as TeamId })]);
+    const md = formatMarkdown(summary);
+    expect(md).toContain('No solo teams appeared in this batch.');
+  });
+});

--- a/packages/cli/src/report.ts
+++ b/packages/cli/src/report.ts
@@ -1,0 +1,176 @@
+import type { TeamId } from '@kurone-kito/oneiron-core';
+import type { GameOutcome } from './batch.ts';
+
+export type BatchSummary = {
+  readonly games: number;
+  readonly winsByTeam: ReadonlyMap<TeamId, number>;
+  readonly drawCount: number;
+  readonly avgRounds: number;
+  readonly minRounds: number;
+  readonly maxRounds: number;
+  /** `null` when no outcome contained any solo team. */
+  readonly soloTeamWinRate: number | null;
+  readonly avgGraveyardSize: number;
+  readonly avgTotalDamage: number;
+};
+
+function average(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  let sum = 0;
+  for (const value of values) sum += value;
+  return sum / values.length;
+}
+
+export function summarise(outcomes: readonly GameOutcome[]): BatchSummary {
+  const games = outcomes.length;
+  const winsByTeam = new Map<TeamId, number>();
+  let drawCount = 0;
+  let minRounds = Number.POSITIVE_INFINITY;
+  let maxRounds = 0;
+  let soloGames = 0;
+  let soloWins = 0;
+  const rounds: number[] = [];
+  const graveyards: number[] = [];
+  const damages: number[] = [];
+
+  for (const outcome of outcomes) {
+    rounds.push(outcome.rounds);
+    graveyards.push(outcome.graveyardSize);
+    damages.push(outcome.totalDamageDealt);
+    if (outcome.rounds < minRounds) minRounds = outcome.rounds;
+    if (outcome.rounds > maxRounds) maxRounds = outcome.rounds;
+
+    if (outcome.winner === null) {
+      drawCount += 1;
+    } else {
+      winsByTeam.set(outcome.winner, (winsByTeam.get(outcome.winner) ?? 0) + 1);
+    }
+
+    if (outcome.soloTeams.length > 0) {
+      soloGames += 1;
+      if (
+        outcome.winner !== null &&
+        outcome.soloTeams.includes(outcome.winner)
+      ) {
+        soloWins += 1;
+      }
+    }
+  }
+
+  return {
+    games,
+    winsByTeam,
+    drawCount,
+    avgRounds: average(rounds),
+    minRounds: games === 0 ? 0 : minRounds,
+    maxRounds,
+    soloTeamWinRate: soloGames === 0 ? null : soloWins / soloGames,
+    avgGraveyardSize: average(graveyards),
+    avgTotalDamage: average(damages),
+  };
+}
+
+function summaryToSerializable(summary: BatchSummary): Record<string, unknown> {
+  return {
+    games: summary.games,
+    winsByTeam: Object.fromEntries(
+      [...summary.winsByTeam.entries()].sort(([a], [b]) => a - b),
+    ),
+    drawCount: summary.drawCount,
+    avgRounds: summary.avgRounds,
+    minRounds: summary.minRounds,
+    maxRounds: summary.maxRounds,
+    soloTeamWinRate: summary.soloTeamWinRate,
+    avgGraveyardSize: summary.avgGraveyardSize,
+    avgTotalDamage: summary.avgTotalDamage,
+  };
+}
+
+export function formatJson(summary: BatchSummary): string {
+  return JSON.stringify(summaryToSerializable(summary));
+}
+
+function csvCell(value: string | number): string {
+  const str = String(value);
+  return /[",\n\r]/.test(str) ? `"${str.replace(/"/g, '""')}"` : str;
+}
+
+export function formatCsv(outcomes: readonly GameOutcome[]): string {
+  const header = [
+    'seed',
+    'winner',
+    'rounds',
+    'survivingTeams',
+    'totalDamageDealt',
+    'graveyardSize',
+    'soloTeams',
+  ].join(',');
+  const lines = [header];
+  for (const outcome of outcomes) {
+    lines.push(
+      [
+        csvCell(outcome.seed),
+        csvCell(outcome.winner ?? ''),
+        csvCell(outcome.rounds),
+        csvCell(outcome.survivingTeams.join(' ')),
+        csvCell(outcome.totalDamageDealt),
+        csvCell(outcome.graveyardSize),
+        csvCell(outcome.soloTeams.join(' ')),
+      ].join(','),
+    );
+  }
+  return lines.join('\n');
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function formatNumber(value: number, digits = 2): string {
+  return value.toFixed(digits);
+}
+
+export function formatMarkdown(summary: BatchSummary): string {
+  const drawPercent =
+    summary.games === 0 ? 0 : summary.drawCount / summary.games;
+  const lines: string[] = [];
+  lines.push('# Batch summary', '');
+  lines.push(`- **Games**: ${summary.games}`);
+  lines.push(
+    `- **Avg rounds**: ${formatNumber(summary.avgRounds)} (min ${summary.minRounds}, max ${summary.maxRounds})`,
+  );
+  lines.push(
+    `- **Draws**: ${summary.drawCount} (${formatPercent(drawPercent)} of games)`,
+  );
+  lines.push('', '## Win rates by team number', '');
+  lines.push('| Team | Wins | Win rate |');
+  lines.push('| ---- | ---- | -------- |');
+  const sortedWins = [...summary.winsByTeam.entries()].sort(
+    ([a], [b]) => a - b,
+  );
+  if (sortedWins.length === 0) {
+    lines.push('| _none_ | 0 | 0.00% |');
+  } else {
+    for (const [team, wins] of sortedWins) {
+      const rate = summary.games === 0 ? 0 : wins / summary.games;
+      lines.push(`| ${team} | ${wins} | ${formatPercent(rate)} |`);
+    }
+  }
+  lines.push('', '## Solo team win rate', '');
+  if (summary.soloTeamWinRate === null) {
+    lines.push('_No solo teams appeared in this batch._');
+  } else {
+    lines.push(
+      `${formatPercent(summary.soloTeamWinRate)} (across games that included a solo team)`,
+    );
+  }
+  lines.push('', '## Card economy', '');
+  lines.push(
+    `- Avg graveyard size at end of game: ${formatNumber(summary.avgGraveyardSize)}`,
+  );
+  lines.push(
+    `- Avg total damage per game: ${formatNumber(summary.avgTotalDamage)}`,
+  );
+  lines.push('');
+  return lines.join('\n');
+}


### PR DESCRIPTION
Closes #130 · Refs roadmap #122 · Depends on #129 (merged)

Implements wave-7's analytics layer on top of the batch runner.
\`summarise(outcomes)\` aggregates \`GameOutcome[]\` into a
\`BatchSummary\` (wins-by-team, draws, round bounds, solo-team
win rate, card-economy averages), and three formatters render
the summary or the raw outcomes for JSON / CSV / Markdown
consumption.

## Summary

- **\`packages/cli/src/report.ts\` (new)** —
  \`summarise(outcomes)\` plus \`formatJson(summary)\`,
  \`formatCsv(outcomes)\`, \`formatMarkdown(summary)\`. JSON
  serialises \`winsByTeam\` as a key-sorted record; CSV escapes
  per RFC 4180; Markdown follows the exact layout from the issue
  (header bullets, win-rate table, solo-team section, card-economy
  bullets).
- **\`packages/cli/src/batch.ts\`** — \`GameOutcome\` gains
  \`soloTeams: readonly TeamId[]\`, computed from the post-setup
  state (\`team.players.length === 1\`). This is what lets
  \`summarise\` produce the solo-team win rate without an extra
  setup snapshot.
- **\`packages/cli/src/cli.ts\`** — \`batch\` subcommand gains
  \`--format json|csv|markdown\` (default \`json\`) and
  \`--output <path>\`. Default JSON now emits
  \`{ summary, outcomes }\` so one call gives both views.
- **\`packages/cli/src/node-runtime.d.ts\`** — \`writeFile\`
  declaration added alongside \`readFile\`.

## Smoke checks

\`\`\`
oneiron batch --player-count 6 --games 3 --seed-start 1 \\
  --format markdown
\`\`\`

produces a complete \`# Batch summary\` document with all four
sections; \`--format csv\` produces a header row + one line per
game.

## Test plan

- [x] \`pnpm run test\` — 261 tests pass
  - \`report.test.ts\` (9): wins/draws/rounds math; \`soloTeamWinRate\`
    null vs computed; averages; empty-outcomes guard; JSON
    round-trips; CSV header + row format incl. empty-winner draw;
    Markdown contains all four sections and a percent table.
  - \`cli.test.ts\` (11, was 7): default-JSON test now also asserts
    the \`summary\` field; three new format tests cover CSV,
    Markdown, and an unknown-format rejection; an \`--output\`
    test writes to a \`mkdtemp\` directory and verifies the file.
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch output now supports multiple formats: JSON, CSV, and Markdown via `--format` flag
  * Batch results can be saved to a file using `--output` flag
  * Batch reports now include comprehensive game statistics (win rates, round counts, graveyard and damage metrics)

* **Tests**
  * Added test coverage for batch output formatting and file operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->