### PR TITLE
feat(core): surface session log entries to the gameplay UI

### DIFF
--- a/packages/core/src/logic/runner.ts
+++ b/packages/core/src/logic/runner.ts
@@ -47,12 +47,30 @@ export type RoundOutput = {
   readonly log: readonly LogEntry[];
 };
 
-function battleLogMessage(result: BattleResult): string {
+export function battleLogMessage(result: BattleResult): string {
   if (result.winner === null) {
     return `Team ${result.teamA} drew with Team ${result.teamB} (${result.encounterType})`;
   }
   const loser = result.winner === result.teamA ? result.teamB : result.teamA;
   return `Team ${result.winner} hit Team ${loser} for ${result.damage} damage (${result.encounterType})`;
+}
+
+export function countDroppedTokenDelta(
+  before: RoundState,
+  after: RoundState,
+): number {
+  const tokensA = before.droppedLifeTokens;
+  const tokensB = after.droppedLifeTokens;
+  if (tokensA === undefined && tokensB === undefined) return 0;
+  let delta = 0;
+  for (const x of ['fire', 'water', 'wood'] as const) {
+    for (const y of ['fire', 'water', 'wood'] as const) {
+      const va = tokensA?.[x]?.[y] ?? 0;
+      const vb = tokensB?.[x]?.[y] ?? 0;
+      delta += vb - va;
+    }
+  }
+  return Math.max(0, delta);
 }
 
 /**
@@ -152,7 +170,7 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
       phase: 'movement',
       message: `Movement resolution: ${resolvedMovement.teamMoves.length} moves resolved`,
     });
-    const movementPenalties = countTokenDelta(beforeMovement, next);
+    const movementPenalties = countDroppedTokenDelta(beforeMovement, next);
     if (movementPenalties > 0) {
       log.push({
         round,
@@ -176,21 +194,6 @@ export function runRound(state: RoundState, inputs: RoundInputs): RoundOutput {
   }
 
   return { state: next, battleResults, log };
-}
-
-function countTokenDelta(a: RoundState, b: RoundState): number {
-  const tokensA = a.droppedLifeTokens;
-  const tokensB = b.droppedLifeTokens;
-  if (tokensA === undefined && tokensB === undefined) return 0;
-  let delta = 0;
-  for (const x of ['fire', 'water', 'wood'] as const) {
-    for (const y of ['fire', 'water', 'wood'] as const) {
-      const va = tokensA?.[x]?.[y] ?? 0;
-      const vb = tokensB?.[x]?.[y] ?? 0;
-      delta += vb - va;
-    }
-  }
-  return Math.max(0, delta);
 }
 
 /** A function that supplies inputs for the next round given current state. */

--- a/packages/core/src/session/session.test.ts
+++ b/packages/core/src/session/session.test.ts
@@ -167,7 +167,11 @@ describe('createSession', () => {
     expect(first.status).toBe('done');
     expect(first.state.round).toBe(2);
     expect(first.state.phase).toBe('battle');
-    expect(second).toEqual(first);
+    // A second step on an already-completed round returns the same
+    // final state but emits no fresh log entries.
+    expect(second.status).toBe('done');
+    expect(second.state).toEqual(first.state);
+    expect(second.log).toEqual([]);
   });
 
   it('resolves empty-hand bot fallback movement without awaiting humans', () => {
@@ -858,8 +862,8 @@ describe('createSession', () => {
     const first = session.step();
     const second = session.step();
 
-    expect(first).toEqual({ status: 'done', state: state });
-    expect(second).toEqual({ status: 'done', state: state });
+    expect(first).toEqual({ status: 'done', state, log: [] });
+    expect(second).toEqual({ status: 'done', state, log: [] });
   });
 
   it('can drive a short multi-round all-bot smoke run to game over', () => {
@@ -887,5 +891,112 @@ describe('createSession', () => {
     }
 
     expect(isGameOver(state)).toBe(true);
+  });
+
+  it('emits per-phase log entries on each step', () => {
+    const initial = setupGame({ playerCount: 4, seed: 11 }, DEFAULT_CONFIG);
+    const controls = new Map<
+      TeamId,
+      {
+        readonly type: 'bot';
+        readonly strategy: ReturnType<typeof randomStrategy>;
+      }
+    >();
+    for (const team of allTeams(initial)) {
+      controls.set(team.teamNumber, {
+        type: 'bot',
+        strategy: randomStrategy(team.teamNumber + 10),
+      });
+    }
+
+    const session = createSession(initial, { controls });
+    const step = session.step();
+    expect(step.status).toBe('done');
+    expect(step.log.length).toBeGreaterThan(0);
+
+    const validPhases = new Set(['battle', 'forbidden', 'movement', 'revival']);
+    for (const entry of step.log) {
+      expect(entry.round).toBe(initial.round);
+      expect(validPhases.has(entry.phase)).toBe(true);
+      expect(typeof entry.message).toBe('string');
+      expect(entry.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('emits the documented battle log message format', () => {
+    const initial = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 3,
+          cards: [fire5],
+        }),
+        makeTeam({
+          id: 2 as NumberToken,
+          position: fireFire,
+          life: 3,
+          cards: [water3],
+        }),
+      ],
+      // Empty deck → forbidden/movement skipped, revival has no
+      // drops, so only battle log entries fire this step.
+      deck: [],
+    });
+    const session = createSession(initial, { controls: new Map() });
+    const step = session.step({
+      battlePlays: new Map([
+        [1 as TeamId, { teamId: 1 as TeamId, card: fire5 }],
+        [2 as TeamId, { teamId: 2 as TeamId, card: water3 }],
+      ]),
+    });
+    const battleEntries = step.log.filter((e) => e.phase === 'battle');
+    expect(battleEntries.length).toBeGreaterThan(0);
+    expect(battleEntries[0]?.message).toMatch(
+      /^Team \d+ (hit Team \d+ for \d+ damage|drew with Team \d+) \(/,
+    );
+  });
+
+  it('emits revival log entries when human teams trigger revival actions', () => {
+    const droppedTokens = createEmptyDroppedTokens();
+    droppedTokens.fire.fire = 2;
+    const initial = stateWith({
+      teams: [
+        makeTeam({
+          id: 1 as NumberToken,
+          position: fireFire,
+          life: 2,
+          cards: [],
+        }),
+        // Second team keeps the game alive past phase 1 so the
+        // session reaches revival rather than declaring victory.
+        makeTeam({
+          id: 2 as NumberToken,
+          position: woodWood,
+          life: 3,
+          cards: [],
+        }),
+      ],
+      phase: 'revival',
+      droppedLifeTokens: droppedTokens,
+    });
+    const session = createSession(initial, {
+      controls: new Map([
+        [1 as TeamId, { type: 'human' as const }],
+        [2 as TeamId, { type: 'human' as const }],
+      ]),
+    });
+    // First step requests revival input from team 1 (team 2 has no
+    // dropped tokens on its cell so it is not eligible).
+    const awaiting = session.step();
+    expect(awaiting.status).toBe('awaiting');
+    const done = session.step({
+      revivalActions: new Map([[1 as TeamId, { type: 'charge-life' }]]),
+    });
+    expect(done.status).toBe('done');
+    const revivalEntries = done.log.filter((e) => e.phase === 'revival');
+    expect(revivalEntries.map((e) => e.message)).toContain(
+      'Team 1 chose charge-life',
+    );
   });
 });

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -20,9 +20,11 @@ import {
   type RoundState,
   type TeamMove,
 } from '../logic/round.ts';
+import { battleLogMessage, countDroppedTokenDelta } from '../logic/runner.ts';
 import type { TeamStrategy } from '../strategy/strategy.ts';
 import type { Card, Element } from '../types/card.ts';
 import type { TeamState } from '../types/grid.ts';
+import type { LogEntry } from '../types/log.ts';
 import type { TeamId } from '../types/token.ts';
 
 export type TeamControl =
@@ -54,8 +56,13 @@ export type SessionStep =
       readonly status: 'awaiting';
       readonly request: HumanInputRequest;
       readonly state: RoundState;
+      readonly log: readonly LogEntry[];
     }
-  | { readonly status: 'done'; readonly state: RoundState };
+  | {
+      readonly status: 'done';
+      readonly state: RoundState;
+      readonly log: readonly LogEntry[];
+    };
 
 const DEFAULT_HUMAN_CONTROL: TeamControl = { type: 'human' };
 function controlFor(
@@ -217,6 +224,7 @@ export function createSession(
 
   function applyBattle(
     battlePlays: ReadonlyMap<TeamId, BattlePlay> | undefined,
+    stepLog: LogEntry[],
   ): void {
     const plays: BattlePlay[] = [];
     for (const team of allTeams(current)) {
@@ -232,11 +240,19 @@ export function createSession(
       plays.push({ teamId, card: battle.card });
     }
 
+    const round = current.round;
     const resolved = resolveBattlePhase(
       current,
       plays,
       config.gameConfig ?? DEFAULT_CONFIG,
     );
+    for (const result of resolved.results) {
+      stepLog.push({
+        round,
+        phase: 'battle',
+        message: battleLogMessage(result),
+      });
+    }
     current = isGameOver(resolved.state)
       ? resolved.state
       : { ...resolved.state, phase: 'forbidden' };
@@ -276,6 +292,7 @@ export function createSession(
   function applyMovement(
     teamMoves: ReadonlyMap<TeamId, TeamMove> | undefined,
     humanTeams: readonly TeamId[],
+    stepLog: LogEntry[],
   ): void {
     if (pendingMovementAttribute === null) {
       throw new Error('Movement attribute missing while resolving movement.');
@@ -313,17 +330,34 @@ export function createSession(
       });
     }
 
+    const round = current.round;
     const resolved = resolveMovementChoices(
       current,
       movementChoices,
-      undefined,
+      (message) => {
+        stepLog.push({ round, phase: 'movement', message });
+      },
       { skipInvalidExplicitChoiceTeamIds: new Set(humanTeams) },
     );
+    const beforeMovement = resolved.state;
     current = advanceMovement(
-      resolved.state,
+      beforeMovement,
       pendingMovementAttribute,
       resolved.teamMoves,
     );
+    stepLog.push({
+      round,
+      phase: 'movement',
+      message: `Movement resolution: ${resolved.teamMoves.length} moves resolved`,
+    });
+    const movementPenalties = countDroppedTokenDelta(beforeMovement, current);
+    if (movementPenalties > 0) {
+      stepLog.push({
+        round,
+        phase: 'movement',
+        message: `Forbidden-cell penalty dropped ${movementPenalties} life token(s)`,
+      });
+    }
     pendingMovementAttribute = null;
     pendingPreparedBotMovementChoices = [];
     pendingPreparedBotMovementTeams = new Set<TeamId>();
@@ -331,6 +365,7 @@ export function createSession(
 
   function applyRevival(
     revivalActions: ReadonlyMap<TeamId, RevivalAction> | undefined,
+    stepLog: LogEntry[],
   ): void {
     const choices = new Map<TeamId, RevivalAction>();
     const eligibleHumanTeams = new Set(
@@ -354,7 +389,15 @@ export function createSession(
       choices.set(teamId, action);
     }
 
+    const round = current.round;
     current = advanceRevival(current, choices);
+    for (const [teamId, action] of choices) {
+      stepLog.push({
+        round,
+        phase: 'revival',
+        message: `Team ${teamId} chose ${action.type}`,
+      });
+    }
   }
 
   function teamControlStrategy(teamId: TeamId): TeamStrategy {
@@ -365,9 +408,12 @@ export function createSession(
     return control.strategy;
   }
 
-  function awaiting(request: HumanInputRequest): SessionStep {
+  function awaiting(
+    request: HumanInputRequest,
+    stepLog: readonly LogEntry[],
+  ): SessionStep {
     pendingRequest = request;
-    return { status: 'awaiting', request, state: current };
+    return { status: 'awaiting', request, state: current, log: stepLog };
   }
 
   return {
@@ -375,9 +421,10 @@ export function createSession(
       return current;
     },
     step(humanInputs) {
+      const stepLog: LogEntry[] = [];
       if (completed || isGameOver(current)) {
         completed = true;
-        return { status: 'done', state: current };
+        return { status: 'done', state: current, log: stepLog };
       }
 
       if (pendingRequest !== null) {
@@ -393,6 +440,7 @@ export function createSession(
                 status: 'awaiting',
                 request: pendingRequest,
                 state: current,
+                log: stepLog,
               };
             }
             break;
@@ -407,6 +455,7 @@ export function createSession(
                 status: 'awaiting',
                 request: pendingRequest,
                 state: current,
+                log: stepLog,
               };
             }
             break;
@@ -421,6 +470,7 @@ export function createSession(
                 status: 'awaiting',
                 request: pendingRequest,
                 state: current,
+                log: stepLog,
               };
             }
             break;
@@ -431,47 +481,76 @@ export function createSession(
       while (true) {
         if (isGameOver(current)) {
           completed = true;
-          return { status: 'done', state: current };
+          return { status: 'done', state: current, log: stepLog };
         }
 
         switch (current.phase) {
           case 'battle': {
             const humanTeams = humanBattleTeams(current, config.controls);
             if (!hasCompleteInputs(humanTeams, humanInputs?.battlePlays)) {
-              return awaiting({ phase: 'battle', humanTeams });
+              return awaiting({ phase: 'battle', humanTeams }, stepLog);
             }
-            applyBattle(humanInputs?.battlePlays);
+            applyBattle(humanInputs?.battlePlays, stepLog);
             humanInputs = undefined;
             continue;
           }
           case 'forbidden': {
+            const round = current.round;
             const forbiddenDraw = drawFromDeck(current.deck, 2);
             if (forbiddenDraw.drawn.length < 2) {
+              stepLog.push({
+                round,
+                phase: 'forbidden',
+                message: 'Deck exhausted: forbidden phase skipped',
+              });
               current = { ...current, phase: 'movement' };
               continue;
             }
+            const cardX = coerceToElementCard(forbiddenDraw.drawn[0] as Card);
+            const cardY = coerceToElementCard(forbiddenDraw.drawn[1] as Card);
             current = advanceForbidden(
               { ...current, deck: forbiddenDraw.remaining },
-              [
-                coerceToElementCard(forbiddenDraw.drawn[0] as Card),
-                coerceToElementCard(forbiddenDraw.drawn[1] as Card),
-              ],
+              [cardX, cardY],
             );
+            stepLog.push({
+              round,
+              phase: 'forbidden',
+              message: `New forbidden cell: (${cardX.element}, ${cardY.element})`,
+            });
             continue;
           }
           case 'movement': {
+            const round = current.round;
+            const justDrawingAttribute = pendingMovementAttribute === null;
             const humanTeams = prepareMovement();
             if (pendingMovementAttribute === null) {
+              if (justDrawingAttribute) {
+                stepLog.push({
+                  round,
+                  phase: 'movement',
+                  message: 'Deck exhausted: movement phase skipped',
+                });
+              }
               continue;
             }
-            if (!hasCompleteInputs(humanTeams, humanInputs?.teamMoves)) {
-              return awaiting({
+            if (justDrawingAttribute) {
+              stepLog.push({
+                round,
                 phase: 'movement',
-                humanTeams,
-                movementAttribute: pendingMovementAttribute,
+                message: `Movement attribute: ${pendingMovementAttribute}`,
               });
             }
-            applyMovement(humanInputs?.teamMoves, humanTeams);
+            if (!hasCompleteInputs(humanTeams, humanInputs?.teamMoves)) {
+              return awaiting(
+                {
+                  phase: 'movement',
+                  humanTeams,
+                  movementAttribute: pendingMovementAttribute,
+                },
+                stepLog,
+              );
+            }
+            applyMovement(humanInputs?.teamMoves, humanTeams, stepLog);
             humanInputs = undefined;
             continue;
           }
@@ -481,11 +560,11 @@ export function createSession(
               config.controls,
             );
             if (!hasCompleteInputs(humanTeams, humanInputs?.revivalActions)) {
-              return awaiting({ phase: 'revival', humanTeams });
+              return awaiting({ phase: 'revival', humanTeams }, stepLog);
             }
-            applyRevival(humanInputs?.revivalActions);
+            applyRevival(humanInputs?.revivalActions, stepLog);
             completed = true;
-            return { status: 'done', state: current };
+            return { status: 'done', state: current, log: stepLog };
           }
         }
       }

--- a/packages/web/src/screens/GameplayScreen.test.tsx
+++ b/packages/web/src/screens/GameplayScreen.test.tsx
@@ -100,6 +100,43 @@ describe('GameplayScreen', () => {
     expect(screen.queryByLabelText(/phase input/i)).toBeNull();
   });
 
+  it('populates the turn log after the user submits a battle round', () => {
+    const teamA = makeTeam({
+      id: 1 as TeamId,
+      position: { x: 'fire', y: 'water' },
+      life: 3,
+      cards: [wood1],
+      gridCards: [fire5, water3],
+    });
+    const teamB = makeTeam({
+      id: 2 as TeamId,
+      position: { x: 'fire', y: 'water' },
+      life: 3,
+      cards: [wood4],
+      gridCards: [wood1, wood4],
+    });
+    const initial = stateWith([teamA, teamB]);
+    const controls = new Map<TeamId, TeamControl>([
+      [1 as TeamId, { type: 'human' }],
+      [2 as TeamId, { type: 'human' }],
+    ]);
+    render(() => (
+      <GameplayScreen
+        initialState={initial}
+        config={{ controls, gameConfig: DEFAULT_CONFIG }}
+      />
+    ));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Submit battle plays' }),
+    );
+    const turnLog = screen.getByLabelText('Turn log');
+    // After one battle resolution + revival, the log should hold at
+    // least the battle outcome line.
+    expect(turnLog.textContent ?? '').toMatch(
+      /Team \d+ (hit Team \d+|drew with Team \d+)/,
+    );
+  });
+
   it('pauses for human battle play and advances the round on submit', () => {
     // Two-team battle on the same cell, both human, both have no cards
     // → forfeit. After both submit, the draw advances to the next round

--- a/packages/web/src/screens/GameplayScreen.tsx
+++ b/packages/web/src/screens/GameplayScreen.tsx
@@ -49,6 +49,7 @@ const REVIVAL_ACTIONS: readonly RevivalAction['type'][] = [
 const MIN_AUTOPLAY_DELAY_MS = 0;
 const MAX_AUTOPLAY_DELAY_MS = 2000;
 const DEFAULT_AUTOPLAY_DELAY_MS = 200;
+const LOG_RETENTION = 500;
 
 function listLivingTeams(state: RoundState): TeamState[] {
   const teams: TeamState[] = [];
@@ -100,10 +101,7 @@ export function GameplayScreen(props: GameplayScreenProps) {
   ]);
   const [viewIndex, setViewIndex] = createSignal(0);
   const [pending, setPending] = createSignal<HumanInputRequest | null>(null);
-  // The session does not currently surface phase-by-phase log entries;
-  // the TurnLog renders an empty list until a logging hook is added in
-  // a follow-up issue.
-  const [log] = createSignal<readonly LogEntry[]>([]);
+  const [log, setLog] = createSignal<readonly LogEntry[]>([]);
   const [over, setOver] = createSignal(false);
 
   const [autoPlayActive, setAutoPlayActive] = createSignal(false);
@@ -193,6 +191,15 @@ export function GameplayScreen(props: GameplayScreenProps) {
   ): 'awaiting' | 'round-done' | 'game-over' {
     const result = session.step(humanInputs);
     pushState(result.state);
+    if (result.log.length > 0) {
+      setLog((prev) => {
+        const merged = [...prev, ...result.log];
+        // Cap retention so long auto-play sessions don't unbounded-grow.
+        return merged.length > LOG_RETENTION
+          ? merged.slice(merged.length - LOG_RETENTION)
+          : merged;
+      });
+    }
 
     if (result.status === 'awaiting') {
       setPending(result.request);


### PR DESCRIPTION
Closes #141 · Refs roadmap #121

\`createSession.step()\` now returns a per-step \`log: readonly
LogEntry[]\` alongside the existing state / status / request
fields, and the accumulator is wired through every phase
applier so the messages match the format \`runRound\` has been
emitting all along. The web gameplay screen consumes the new
field, so the existing \`<TurnLog>\` finally renders real round
events.

## Summary

- **\`SessionStep\` both variants** gain
  \`readonly log: readonly LogEntry[]\`. Empty array = no new
  events this step (re-entering a completed session, or an
  awaiting return that didn't advance the phase).
- **Phase appliers** emit messages identical to \`runRound\`'s:
  - \`applyBattle\` → one entry per \`BattleResult\` via the
    now-exported \`battleLogMessage\`.
  - Forbidden block → \`"New forbidden cell: (X, Y)"\` or
    \`"Deck exhausted: forbidden phase skipped"\`.
  - Movement block → \`"Movement attribute: <element>"\`
    (gated on a \`justDrawingAttribute\` flag so it doesn't
    re-emit when the session resumes after awaiting),
    \`resolveMovementChoices\`' event-logger callback,
    \`"Movement resolution: N moves resolved"\`, and the
    forbidden-cell penalty line.
  - \`applyRevival\` → \`"Team N chose <action.type>"\`.
- **\`runner.ts\`** — \`battleLogMessage\` and
  \`countDroppedTokenDelta\` (the renamed-and-exported former
  private \`countTokenDelta\`) are now exported. \`runRound\`
  switches to the exported helper; no behavioural change.
- **\`GameplayScreen.tsx\`** — log signal is now mutable;
  \`drive()\` appends \`result.log\` after each \`session.step\`
  call, with a 500-entry retention cap to keep long auto-play
  sessions bounded.

## Test plan

- [x] \`pnpm run test\` — **269 tests pass** (4 new)
  - \`session.test.ts\`: all-bot round emits a non-empty log
    whose entries all have valid \`{round, phase, message}\`;
    forced two-team battle produces a \`battleLogMessage\`-
    formatted entry; human revival emits
    \`"Team 1 chose charge-life"\`.
  - Existing \`keeps returning done\` assertions loosened from
    \`toEqual(first)\` to separately check status + state + empty
    log (a second step on an already-completed session emits an
    empty buffer, which is the intended semantic).
  - \`GameplayScreen.test.tsx\`: forced battle submit puts a
    \`/Team \\d+ (hit|drew with)/\` line into \`<TurnLog>\`.
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)