### PR TITLE
feat(web): refactor leaf UI components for touch interactions

### DIFF
--- a/packages/web/src/components/TurnLog.test.tsx
+++ b/packages/web/src/components/TurnLog.test.tsx
@@ -17,23 +17,38 @@ describe('TurnLog', () => {
     expect(screen.getByLabelText('Turn log')).toBeTruthy();
   });
 
-  it('renders all entries', () => {
-    render(() => <TurnLog entries={entries} />);
+  it('renders all entries when expanded', () => {
+    render(() => <TurnLog entries={entries} defaultOpen={true} />);
     expect(screen.getByText('Team 1 vs Team 2')).toBeTruthy();
     expect(screen.getByText('Team 1 moved')).toBeTruthy();
     expect(screen.getByText('Team 3 vs Team 4')).toBeTruthy();
   });
 
   it('renders newest entry first (reverse chronological)', () => {
-    render(() => <TurnLog entries={entries} />);
+    render(() => <TurnLog entries={entries} defaultOpen={true} />);
     const items = screen.getAllByRole('listitem');
     expect(items[0]?.textContent).toContain('Team 3 vs Team 4');
     expect(items[items.length - 1]?.textContent).toContain('Team 1 vs Team 2');
   });
 
   it('shows round and phase labels', () => {
-    render(() => <TurnLog entries={[entries[0] as LogEntry]} />);
+    render(() => (
+      <TurnLog entries={[entries[0] as LogEntry]} defaultOpen={true} />
+    ));
     expect(screen.getByText('R1')).toBeTruthy();
     expect(screen.getByText('battle')).toBeTruthy();
+  });
+
+  it('defaults to collapsed', () => {
+    const { container } = render(() => <TurnLog entries={entries} />);
+    const details = container.querySelector('details.turn-log__container');
+    expect(details).toBeTruthy();
+    // open is the canonical attribute; absence means closed.
+    expect((details as HTMLDetailsElement).open).toBe(false);
+  });
+
+  it('renders the summary as a tap-able disclosure', () => {
+    render(() => <TurnLog entries={entries} />);
+    expect(screen.getByText('Turn Log').tagName.toLowerCase()).toBe('summary');
   });
 });

--- a/packages/web/src/components/TurnLog.tsx
+++ b/packages/web/src/components/TurnLog.tsx
@@ -3,6 +3,12 @@ import { createEffect, createSignal, For } from 'solid-js';
 
 type Props = {
   entries: LogEntry[];
+  /**
+   * Whether the log starts expanded. Defaults to `false` so the
+   * mobile layout doesn't pre-claim vertical space; tests and
+   * desktop callers can pass `true` to opt out.
+   */
+  defaultOpen?: boolean;
 };
 
 export function TurnLog(props: Props) {
@@ -23,18 +29,22 @@ export function TurnLog(props: Props) {
 
   return (
     <section class="turn-log" aria-label="Turn log">
-      <h2 class="turn-log__title">Turn Log</h2>
-      <ol class="turn-log__list" ref={listRef}>
-        <For each={sorted()}>
-          {(entry) => (
-            <li class="turn-log__entry">
-              <span class="turn-log__round">R{entry.round}</span>
-              <span class="turn-log__phase">{entry.phase}</span>
-              <span class="turn-log__message">{entry.message}</span>
-            </li>
-          )}
-        </For>
-      </ol>
+      <details class="turn-log__container" open={props.defaultOpen ?? false}>
+        <summary class="turn-log__summary">Turn Log</summary>
+        <div class="turn-log__body">
+          <ol class="turn-log__list" ref={listRef}>
+            <For each={sorted()}>
+              {(entry) => (
+                <li class="turn-log__entry">
+                  <span class="turn-log__round">R{entry.round}</span>
+                  <span class="turn-log__phase">{entry.phase}</span>
+                  <span class="turn-log__message">{entry.message}</span>
+                </li>
+              )}
+            </For>
+          </ol>
+        </div>
+      </details>
     </section>
   );
 }

--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -1,5 +1,6 @@
 import { render } from 'solid-js/web';
 import './styles/tokens.css';
+import './styles/components.css';
 import { App } from './App.tsx';
 
 const root = document.getElementById('root');

--- a/packages/web/src/styles/components.css
+++ b/packages/web/src/styles/components.css
@@ -1,0 +1,237 @@
+/*
+ * Touch-friendly styles for the wave-8 leaf UI components.
+ * Each rule consumes the design tokens from tokens.css instead
+ * of re-inventing its own units. Anything interactive respects
+ * --touch-min (44 px) as a minimum hit area.
+ */
+
+/* --- GameGrid (Grid.tsx) -------------------------------------- */
+
+.game-grid {
+  width: 100%;
+}
+
+.game-grid__table {
+  /* Fixed layout keeps each cell at 1/3 of the table width so the
+   * 3x3 visual layout holds at 320 dp without horizontal overflow. */
+  table-layout: fixed;
+  width: 100%;
+  max-width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-small);
+}
+
+.game-grid__col-label,
+.game-grid__row-label {
+  padding: var(--space-1);
+  color: var(--color-fg-muted);
+  font-weight: 500;
+  text-align: center;
+  text-transform: capitalize;
+}
+
+.game-grid__corner {
+  width: 2rem;
+}
+
+.game-grid__cell {
+  aspect-ratio: 1;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  padding: var(--space-1);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  vertical-align: top;
+}
+
+.game-grid__cell--forbidden {
+  background: color-mix(
+    in srgb,
+    var(--color-fire) 18%,
+    var(--color-bg-elevated)
+  );
+  border-color: var(--color-fire);
+}
+
+.grid-cell__team {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  margin: 0 var(--space-1) var(--space-1) 0;
+  padding: 2px var(--space-1);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  font-size: var(--type-small);
+  line-height: 1;
+}
+
+.grid-cell__token {
+  font-weight: 700;
+}
+
+.grid-cell__facing {
+  color: var(--color-fg-muted);
+}
+
+.grid-cell__life {
+  color: var(--color-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+/* --- Hand ----------------------------------------------------- */
+
+.hand {
+  width: 100%;
+}
+
+.hand__label {
+  margin: 0 0 var(--space-1);
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.hand__cards {
+  /* Horizontal-scroll list with snap. Long hands stay in a bounded
+   * row instead of pushing the layout wider than the viewport. */
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0 0 var(--space-1);
+  list-style: none;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scrollbar-width: thin;
+  -webkit-overflow-scrolling: touch;
+}
+
+.hand__card {
+  flex: 0 0 auto;
+  min-width: var(--touch-min);
+  scroll-snap-align: start;
+}
+
+/* --- CardFace ------------------------------------------------- */
+
+.card {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  width: clamp(var(--touch-min), 14vw, 4rem);
+  aspect-ratio: 3 / 4;
+  padding: var(--space-2) var(--space-1);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  box-shadow: var(--shadow-1);
+  color: var(--color-fg);
+  font-size: var(--type-body);
+  user-select: none;
+}
+
+.card--fire {
+  border-color: var(--color-fire);
+}
+.card--water {
+  border-color: var(--color-water);
+}
+.card--wood {
+  border-color: var(--color-wood);
+}
+
+.card--joker {
+  border-color: var(--color-fg);
+  background: color-mix(in srgb, var(--color-fg) 4%, var(--color-bg-elevated));
+}
+
+.card--back {
+  background: var(--color-fg-muted);
+  color: var(--color-bg-elevated);
+}
+
+.card__symbol {
+  font-size: clamp(1.1rem, 4vw, 1.5rem);
+  line-height: 1;
+}
+
+.card__value {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.card__label {
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+/* --- TurnLog -------------------------------------------------- */
+
+.turn-log {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-bg-elevated);
+}
+
+.turn-log__summary {
+  /* Native <summary> with the disclosure caret. Min height matches
+   * the touch-target token. */
+  display: list-item;
+  padding: var(--space-2) var(--space-3);
+  min-height: var(--touch-min);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: var(--type-body);
+}
+
+.turn-log__summary::marker {
+  color: var(--color-fg-muted);
+}
+
+.turn-log__body {
+  padding: 0 var(--space-3) var(--space-2);
+}
+
+.turn-log__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  max-height: 50vh;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.turn-log__entry {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  gap: var(--space-2);
+  align-items: baseline;
+  padding: var(--space-1) 0;
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--type-small);
+}
+
+.turn-log__entry:last-child {
+  border-bottom: none;
+}
+
+.turn-log__round,
+.turn-log__phase {
+  color: var(--color-fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.turn-log__phase {
+  text-transform: capitalize;
+}
+
+.turn-log__message {
+  color: var(--color-fg);
+}

--- a/packages/web/src/styles/components.test.ts
+++ b/packages/web/src/styles/components.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const componentsCss = readFileSync(join(here, 'components.css'), 'utf8');
+
+/**
+ * The component stylesheet is the single source of truth for the
+ * touch-friendly mobile-first behaviour required by #147. These
+ * tests assert structural rules that the matching components rely
+ * on at runtime — they are intentionally lighter than full visual
+ * regressions, since vitest + jsdom don't apply layout.
+ */
+describe('components.css — touch-friendly mobile rules', () => {
+  describe('GameGrid', () => {
+    it('uses a fixed table layout so the 3x3 fits without overflow', () => {
+      expect(componentsCss).toMatch(
+        /\.game-grid__table[\s\S]*?table-layout:\s*fixed/,
+      );
+      expect(componentsCss).toMatch(
+        /\.game-grid__table[\s\S]*?max-width:\s*100%/,
+      );
+    });
+
+    it('gives each cell aspect-ratio: 1 and the touch-min hit area', () => {
+      expect(componentsCss).toMatch(
+        /\.game-grid__cell[\s\S]*?aspect-ratio:\s*1/,
+      );
+      expect(componentsCss).toMatch(
+        /\.game-grid__cell[\s\S]*?min-(width|height):\s*var\(--touch-min\)/,
+      );
+    });
+  });
+
+  describe('Hand', () => {
+    it('uses horizontal scroll with snap to keep long hands bounded', () => {
+      expect(componentsCss).toMatch(/\.hand__cards[\s\S]*?overflow-x:\s*auto/);
+      expect(componentsCss).toMatch(
+        /\.hand__cards[\s\S]*?scroll-snap-type:\s*x mandatory/,
+      );
+    });
+
+    it('each card has at least the touch-min hit width', () => {
+      expect(componentsCss).toMatch(
+        /\.hand__card[\s\S]*?min-width:\s*var\(--touch-min\)/,
+      );
+    });
+  });
+
+  describe('CardFace', () => {
+    it('scales via the type / spacing tokens instead of fixed pixels', () => {
+      expect(componentsCss).toMatch(/\.card[\s\S]*?width:\s*clamp\(/);
+      expect(componentsCss).toMatch(/\.card[\s\S]*?aspect-ratio:\s*3 \/ 4/);
+    });
+  });
+
+  describe('TurnLog', () => {
+    it('exposes a tap-able summary at least touch-min tall', () => {
+      expect(componentsCss).toMatch(
+        /\.turn-log__summary[\s\S]*?min-height:\s*var\(--touch-min\)/,
+      );
+    });
+
+    it('caps body height so the log can scroll independently', () => {
+      expect(componentsCss).toMatch(
+        /\.turn-log__list[\s\S]*?max-height:\s*\d+vh/,
+      );
+      expect(componentsCss).toMatch(
+        /\.turn-log__list[\s\S]*?overflow-y:\s*auto/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #147 · Refs roadmap #145 · Builds on #146

Lands the touch-friendly styling for the four leaf components
ahead of the GameplayScreen rework in #149. All rules consume
the design tokens from #146 so screen-level work doesn't have
to re-tune the same units.

## Summary

- **\`packages/web/src/styles/components.css\` (new)** — single
  source of styles for the four leaves:
  - **GameGrid**: fixed-layout table, \`aspect-ratio: 1\` cells
    that hit the \`--touch-min\` floor; forbidden cells tint
    against the fire accent.
  - **Hand**: horizontal-scroll list with \`scroll-snap-type:
    x mandatory\`; each tile floors at \`--touch-min\` wide so
    long hands stay bounded.
  - **CardFace**: \`width: clamp(var(--touch-min), 14vw, 4rem)\`,
    fixed \`aspect-ratio: 3 / 4\`. Element borders pick up the
    fire / water / wood accents.
  - **TurnLog**: tap-able summary at least \`--touch-min\` tall;
    body list capped at \`50vh\` with \`overflow-y: auto\` so it
    scrolls inside its drawer rather than pushing the page.
- **\`TurnLog.tsx\`** wrapped in \`<details>\` (collapsed by
  default). New optional \`defaultOpen?: boolean\` prop opens it
  eagerly when the caller wants the log expanded.
- **\`index.tsx\`** imports the new stylesheet once alongside
  \`tokens.css\`.

## Test plan

- [x] \`pnpm run test\` — **301 tests pass**
  - **components.test.ts (new, 7)** — asserts the structural
    CSS rules each component relies on at runtime
    (\`table-layout: fixed\`, \`aspect-ratio: 1\`, \`overflow-x:
    auto\` + snap, \`clamp(…)\` sizing, \`min-height:
    var(--touch-min)\` summary, body \`max-height\` + scroll).
  - **TurnLog.test.tsx (2 new + 4 existing adapted)** — new
    cases verify collapsed-by-default and that the title is
    rendered as a \`<summary>\`; existing cases pass
    \`defaultOpen={true}\` because the new semantic hides
    children from the visible-text query.
- [x] \`pnpm -r run typecheck\` — clean
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)