### PR TITLE
feat(web): SetupScreen mobile layout

### DIFF
--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -1,5 +1,6 @@
 import { render } from 'solid-js/web';
 import './styles/tokens.css';
+import './screens/setup-screen.css';
 import { App } from './App.tsx';
 
 const root = document.getElementById('root');

--- a/packages/web/src/screens/SetupScreen.test.tsx
+++ b/packages/web/src/screens/SetupScreen.test.tsx
@@ -184,4 +184,31 @@ describe('SetupScreen', () => {
     fireEvent.submit(screen.getByRole('button', { name: 'Start game' }).form);
     expect(onStart).not.toHaveBeenCalled();
   });
+
+  describe('mobile layout', () => {
+    it('keeps the A–E overrides collapsed by default', () => {
+      const { container } = render(() => (
+        <SetupScreen onStart={() => undefined} />
+      ));
+      const details = container.querySelector('details.setup-screen__advanced');
+      expect(details).toBeTruthy();
+      expect((details as HTMLDetailsElement).open).toBe(false);
+      // The summary label reflects the "advanced" framing.
+      expect(screen.getByText('A-E values (advanced)')).toBeTruthy();
+    });
+
+    it('still exposes the A–E controls when the user expands the override section', () => {
+      const { container } = render(() => (
+        <SetupScreen onStart={() => undefined} />
+      ));
+      const details = container.querySelector(
+        'details.setup-screen__advanced',
+      ) as HTMLDetailsElement;
+      details.open = true;
+      // The model exposes the labelled inputs once the details element
+      // becomes visible to accessibility queries.
+      expect(screen.getByLabelText('Card copies (A)')).toBeTruthy();
+      expect(screen.getByLabelText('Damage overflow factor (E)')).toBeTruthy();
+    });
+  });
 });

--- a/packages/web/src/screens/SetupScreen.tsx
+++ b/packages/web/src/screens/SetupScreen.tsx
@@ -143,9 +143,9 @@ export function SetupScreen(props: Props) {
   }
 
   return (
-    <section aria-label="Game setup">
-      <header>
-        <p>Wave-6 setup</p>
+    <section class="setup-screen" aria-label="Game setup">
+      <header class="setup-screen__header">
+        <p class="setup-screen__eyebrow">Wave-6 setup</p>
         <h1>Dream Duels Setup</h1>
         <p>
           Configure the roster, seed, and A-E values before handing the table to
@@ -153,61 +153,70 @@ export function SetupScreen(props: Props) {
         </p>
       </header>
 
-      <form onSubmit={handleSubmit}>
-        <fieldset>
+      <form class="setup-screen__form" onSubmit={handleSubmit}>
+        <fieldset class="setup-screen__group">
           <legend>Match setup</legend>
 
-          <label for="player-count">Player count</label>
-          <input
-            id="player-count"
-            type="number"
-            min={MIN_PLAYER_COUNT}
-            max={MAX_PLAYER_COUNT}
-            step="1"
-            value={playerCount()}
-            onInput={(event) =>
-              setPlayerCount(
-                clampPlayerCount(
-                  updateInteger(
-                    event.currentTarget.valueAsNumber,
-                    playerCount(),
-                  ),
-                ),
-              )
-            }
-          />
-
-          <label for="seed">Seed</label>
-          <div>
+          <label class="setup-screen__field" for="player-count">
+            <span class="setup-screen__field-label">Player count</span>
             <input
-              id="seed"
-              type="text"
-              inputMode="numeric"
-              value={seedText()}
-              onInput={(event) => setSeedText(event.currentTarget.value)}
-              onBlur={commitSeedText}
+              id="player-count"
+              type="number"
+              min={MIN_PLAYER_COUNT}
+              max={MAX_PLAYER_COUNT}
+              step="1"
+              value={playerCount()}
+              onInput={(event) =>
+                setPlayerCount(
+                  clampPlayerCount(
+                    updateInteger(
+                      event.currentTarget.valueAsNumber,
+                      playerCount(),
+                    ),
+                  ),
+                )
+              }
             />
-            <button
-              type="button"
-              onClick={() => {
-                const nextSeed = createRandomSeed();
-                setSeed(nextSeed);
-                setSeedText(String(nextSeed));
-              }}
-              aria-label="Randomise seed"
-            >
-              Randomise seed
-            </button>
+          </label>
+
+          <div class="setup-screen__field">
+            <label class="setup-screen__field-label" for="seed">
+              Seed
+            </label>
+            <div class="setup-screen__seed-row">
+              <input
+                id="seed"
+                type="text"
+                inputMode="numeric"
+                value={seedText()}
+                onInput={(event) => setSeedText(event.currentTarget.value)}
+                onBlur={commitSeedText}
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  const nextSeed = createRandomSeed();
+                  setSeed(nextSeed);
+                  setSeedText(String(nextSeed));
+                }}
+                aria-label="Randomise seed"
+              >
+                Randomise seed
+              </button>
+            </div>
           </div>
         </fieldset>
 
-        <fieldset>
+        <fieldset class="setup-screen__group">
           <legend>Per-team control</legend>
-          <ul aria-label="Derived teams">
+          <ul class="setup-screen__team-list" aria-label="Derived teams">
             <For each={teamSummaries()}>
               {(team) => (
-                <li>
-                  <label for={`team-control-${team.teamId}`}>
+                <li class="setup-screen__team-row">
+                  <label
+                    class="setup-screen__team-label"
+                    for={`team-control-${team.teamId}`}
+                  >
                     {team.label}
                   </label>
                   <select
@@ -223,7 +232,9 @@ export function SetupScreen(props: Props) {
                     <option value="human">Human</option>
                     <option value="bot">Bot</option>
                   </select>
-                  <span>{team.memberCount} player(s)</span>
+                  <span class="setup-screen__team-meta">
+                    {team.memberCount} player(s)
+                  </span>
                 </li>
               )}
             </For>
@@ -231,14 +242,14 @@ export function SetupScreen(props: Props) {
         </fieldset>
 
         <Show when={startBlocked()}>
-          <p role="status">
+          <p class="setup-screen__status" role="status">
             Current engine start is capped at 18 players because the 3x3 grid
             can host at most 9 teams.
           </p>
         </Show>
 
-        <details>
-          <summary>A-E values</summary>
+        <details class="setup-screen__advanced">
+          <summary>A-E values (advanced)</summary>
 
           <label for="config-a">Card copies (A)</label>
           <input
@@ -316,9 +327,15 @@ export function SetupScreen(props: Props) {
           />
         </details>
 
-        <button type="submit" disabled={startBlocked()}>
-          Start game
-        </button>
+        <div class="setup-screen__actions">
+          <button
+            class="setup-screen__submit"
+            type="submit"
+            disabled={startBlocked()}
+          >
+            Start game
+          </button>
+        </div>
       </form>
     </section>
   );

--- a/packages/web/src/screens/setup-screen.css
+++ b/packages/web/src/screens/setup-screen.css
@@ -1,0 +1,240 @@
+/*
+ * Mobile-first layout for SetupScreen.
+ *
+ * Single-column vertical stacking with fluid full-width inputs.
+ * A–E overrides live inside a collapsed-by-default <details>.
+ * The submit button is full-width and sticks to the bottom of
+ * the viewport so the form doesn't require the user to scroll
+ * past every per-team row before they can start the game.
+ *
+ * Tap-targets respect --touch-min from tokens.css. The form
+ * stays single column on wider viewports; the only growth on
+ * tablet/desktop is a wider container max-width.
+ */
+
+.setup-screen {
+  display: block;
+  max-width: min(640px, 100%);
+  margin: 0 auto;
+  padding: var(--space-4);
+  padding-bottom: calc(var(--space-7) + var(--touch-min));
+}
+
+.setup-screen__header {
+  margin: 0 0 var(--space-5);
+}
+
+.setup-screen__header > h1 {
+  margin: var(--space-1) 0;
+}
+
+.setup-screen__eyebrow {
+  margin: 0;
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.setup-screen__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.setup-screen__group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-bg-elevated);
+}
+
+.setup-screen__group > legend {
+  padding: 0 var(--space-1);
+  color: var(--color-fg);
+  font-weight: 600;
+}
+
+.setup-screen__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.setup-screen__field-label {
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.setup-screen__field input,
+.setup-screen__field select,
+.setup-screen__advanced input,
+.setup-screen__team-row select {
+  min-height: var(--touch-min);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-size: var(--type-body);
+  font-variant-numeric: tabular-nums;
+}
+
+.setup-screen__field input:focus-visible,
+.setup-screen__field select:focus-visible,
+.setup-screen__advanced input:focus-visible,
+.setup-screen__team-row select:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.setup-screen__field input {
+  width: 100%;
+}
+
+.setup-screen__seed-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: stretch;
+}
+
+.setup-screen__seed-row > input {
+  flex: 1 1 8rem;
+  min-width: 0;
+}
+
+.setup-screen__seed-row > button {
+  flex: 0 0 auto;
+  min-height: var(--touch-min);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-size: var(--type-small);
+  cursor: pointer;
+}
+
+.setup-screen__team-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.setup-screen__team-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    "label  select"
+    "meta   meta";
+  column-gap: var(--space-2);
+  row-gap: var(--space-1);
+  align-items: center;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.setup-screen__team-row:last-child {
+  border-bottom: none;
+}
+
+.setup-screen__team-label {
+  grid-area: label;
+  font-weight: 500;
+}
+
+.setup-screen__team-row > select {
+  grid-area: select;
+  min-width: clamp(6rem, 28vw, 9rem);
+}
+
+.setup-screen__team-meta {
+  grid-area: meta;
+  color: var(--color-fg-muted);
+  font-size: var(--type-small);
+}
+
+.setup-screen__status {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-fire);
+  border-radius: var(--radius-1);
+  background: color-mix(
+    in srgb,
+    var(--color-fire) 8%,
+    var(--color-bg-elevated)
+  );
+  color: var(--color-fg);
+  font-size: var(--type-small);
+}
+
+.setup-screen__advanced {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-bg-elevated);
+}
+
+.setup-screen__advanced > summary {
+  display: list-item;
+  min-height: var(--touch-min);
+  padding: var(--space-1) 0;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.setup-screen__advanced label {
+  display: block;
+  margin-top: var(--space-3);
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.setup-screen__advanced input {
+  width: 100%;
+  margin-top: var(--space-1);
+}
+
+.setup-screen__actions {
+  /* Sticky to the bottom of the viewport so the submit affordance
+   * is always reachable without scrolling past the team list. */
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  margin-top: var(--space-4);
+  padding: var(--space-3) 0;
+  background: linear-gradient(to top, var(--color-bg) 60%, transparent 100%);
+}
+
+.setup-screen__submit {
+  flex: 1 1 auto;
+  min-height: var(--touch-min);
+  padding: var(--space-3);
+  border: none;
+  border-radius: var(--radius-2);
+  background: var(--color-accent);
+  color: white;
+  font-size: var(--type-heading-3);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.setup-screen__submit:disabled {
+  background: var(--color-border);
+  color: var(--color-fg-muted);
+  cursor: not-allowed;
+}
+
+.setup-screen__submit:focus-visible {
+  outline: 2px solid var(--color-fg);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
Closes #148 · Refs roadmap #145 · Builds on #146

Restyles the wave-6 setup form for 320 dp single-column use.
Model layer (\`setup-screen-model.ts\`) and its 5-test suite are
untouched; the only logical changes are wrapping the player-
count input inside its label and grouping the seed input +
randomise button into a flex row.

## Summary

- **\`packages/web/src/screens/setup-screen.css\` (new)** —
  vertical stacking, full-width fields, sticky bottom submit.
  Each input / select / button hits \`--touch-min\` (44 px),
  outlines focus state, and falls back gracefully on wider
  viewports by capping the container at 640 px (centered,
  not forked into a desktop layout).
- **\`SetupScreen.tsx\`**: structural class names added
  (\`setup-screen\`, \`setup-screen__group\`,
  \`setup-screen__field\`, \`setup-screen__team-row\`,
  \`setup-screen__advanced\`, \`setup-screen__actions\`,
  \`setup-screen__submit\`). Player-count input nested inside
  its \`<label>\`; seed input + randomise button grouped under
  \`setup-screen__seed-row\`. A–E \`<details>\` retitled
  \`"A-E values (advanced)"\` and styled as the dashed-border
  secondary block.
- **\`index.tsx\`** imports the new stylesheet once.

## Test plan

- [x] \`pnpm run test\` — **294 tests pass**
  - 8 existing cases still pass — model + DOM associations
    intact (\`getByLabelText\` / \`getByText\` find the same
    nodes).
  - 2 new cases under a \`mobile layout\` describe block:
    A–E overrides default to collapsed; expanding makes all
    A–E inputs reachable by label.
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)