### PR TITLE
feat(web): GameplayScreen mobile layout (bottom-sheet + drawer)

### DIFF
--- a/packages/web/src/index.tsx
+++ b/packages/web/src/index.tsx
@@ -2,6 +2,7 @@ import { render } from 'solid-js/web';
 import './styles/tokens.css';
 import './styles/components.css';
 import './screens/setup-screen.css';
+import './screens/gameplay-screen.css';
 import { App } from './App.tsx';
 
 const root = document.getElementById('root');

--- a/packages/web/src/screens/GameplayScreen.test.tsx
+++ b/packages/web/src/screens/GameplayScreen.test.tsx
@@ -191,7 +191,11 @@ describe('GameplayScreen', () => {
     const initial = setupGame({ playerCount: 4, seed: 7 }, DEFAULT_CONFIG);
     const config = botConfigFor(initial, 50);
     render(() => <GameplayScreen initialState={initial} config={config} />);
-    // No auto-advance: history holds exactly the initial frame.
+    // History + auto-play live inside the off-canvas drawer; open
+    // it to read the frame counter and reach Play.
+    fireEvent.click(
+      screen.getByRole('button', { name: /Open auxiliary controls/i }),
+    );
     const historySection = screen.getByLabelText('State history');
     expect(historySection.textContent ?? '').toMatch(/Frame\s*1\s*\/\s*1/);
     expect(screen.getByRole('button', { name: 'Play' })).toBeTruthy();
@@ -203,6 +207,9 @@ describe('GameplayScreen', () => {
       const initial = setupGame({ playerCount: 4, seed: 11 }, DEFAULT_CONFIG);
       const config = botConfigFor(initial, 60);
       render(() => <GameplayScreen initialState={initial} config={config} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Open auxiliary controls/i }),
+      );
       const play = screen.getByRole('button', { name: 'Play' });
       fireEvent.click(play);
       // Default delay is 200ms; flush a few ticks worth.
@@ -226,6 +233,9 @@ describe('GameplayScreen', () => {
       const initial = setupGame({ playerCount: 4, seed: 13 }, DEFAULT_CONFIG);
       const config = botConfigFor(initial, 80);
       render(() => <GameplayScreen initialState={initial} config={config} />);
+      fireEvent.click(
+        screen.getByRole('button', { name: /Open auxiliary controls/i }),
+      );
       fireEvent.click(screen.getByRole('button', { name: 'Play' }));
       await vi.advanceTimersByTimeAsync(800);
       fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
@@ -270,12 +280,96 @@ describe('GameplayScreen', () => {
     ));
     expect(screen.getByLabelText(/phase input — battle/i)).toBeTruthy();
     // Step back into history — submit a turn first so there's a
-    // prior frame to revisit.
+    // prior frame to revisit. The Previous control lives in the
+    // off-canvas drawer; open it before clicking.
     fireEvent.click(
       screen.getByRole('button', { name: 'Submit battle plays' }),
+    );
+    fireEvent.click(
+      screen.getByRole('button', { name: /Open auxiliary controls/i }),
     );
     fireEvent.click(screen.getByRole('button', { name: /Previous/ }));
     expect(screen.queryByLabelText(/phase input — battle/i)).toBeNull();
     expect(screen.getByLabelText('History view banner')).toBeTruthy();
+  });
+
+  describe('mobile layout', () => {
+    function mixedConfig(): {
+      initial: ReturnType<typeof stateWith>;
+      controls: Map<TeamId, TeamControl>;
+    } {
+      const teamA = makeTeam({
+        id: 1 as TeamId,
+        position: { x: 'fire', y: 'water' },
+        life: 3,
+        cards: [wood1],
+      });
+      const teamB = makeTeam({
+        id: 2 as TeamId,
+        position: { x: 'fire', y: 'water' },
+        life: 3,
+        cards: [wood4],
+      });
+      const initial = stateWith([teamA, teamB]);
+      const controls = new Map<TeamId, TeamControl>([
+        [1 as TeamId, { type: 'human' }],
+        [2 as TeamId, { type: 'human' }],
+      ]);
+      return { initial, controls };
+    }
+
+    it('renders the phase input panel as a bottom-sheet dialog when awaiting', () => {
+      const { initial, controls } = mixedConfig();
+      render(() => (
+        <GameplayScreen
+          initialState={initial}
+          config={{ controls, gameConfig: DEFAULT_CONFIG }}
+        />
+      ));
+      const sheet = screen.getByLabelText(/phase input — battle/i);
+      expect(sheet.getAttribute('role')).toBe('dialog');
+      expect(sheet.className).toMatch(/gameplay-screen__sheet/);
+    });
+
+    it('opens and closes the auxiliary drawer via the hamburger button', () => {
+      const initial = setupGame({ playerCount: 4, seed: 21 }, DEFAULT_CONFIG);
+      const config = botConfigFor(initial, 200);
+      render(() => <GameplayScreen initialState={initial} config={config} />);
+      const opener = screen.getByRole('button', {
+        name: /Open auxiliary controls/i,
+      });
+      // Closed by default.
+      expect(opener.getAttribute('aria-expanded')).toBe('false');
+      expect(screen.queryByLabelText('Auxiliary controls')).toBeNull();
+      // Open.
+      fireEvent.click(opener);
+      expect(screen.getByLabelText('Auxiliary controls')).toBeTruthy();
+      expect(opener.getAttribute('aria-expanded')).toBe('true');
+      // Close via the in-drawer × button.
+      fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+      expect(screen.queryByLabelText('Auxiliary controls')).toBeNull();
+    });
+
+    it('drives auto-play from inside the drawer', async () => {
+      vi.useFakeTimers();
+      try {
+        const initial = setupGame({ playerCount: 4, seed: 33 }, DEFAULT_CONFIG);
+        const config = botConfigFor(initial, 300);
+        render(() => <GameplayScreen initialState={initial} config={config} />);
+        fireEvent.click(
+          screen.getByRole('button', { name: /Open auxiliary controls/i }),
+        );
+        // Auto-play section is only visible to all-bot configs.
+        expect(screen.getByLabelText('Auto-play controls')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+        await vi.advanceTimersByTimeAsync(800);
+        const historySection = screen.getByLabelText('State history');
+        expect(historySection.textContent ?? '').not.toMatch(
+          /Frame\s*1\s*\/\s*1/,
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/web/src/screens/GameplayScreen.tsx
+++ b/packages/web/src/screens/GameplayScreen.tsx
@@ -109,6 +109,15 @@ export function GameplayScreen(props: GameplayScreenProps) {
     DEFAULT_AUTOPLAY_DELAY_MS,
   );
 
+  const [drawerOpen, setDrawerOpen] = createSignal(false);
+
+  function toggleDrawer(): void {
+    setDrawerOpen((open) => !open);
+  }
+  function closeDrawer(): void {
+    setDrawerOpen(false);
+  }
+
   const headState = createMemo(() => {
     const frames = history();
     return frames[frames.length - 1] as RoundState;
@@ -347,86 +356,28 @@ export function GameplayScreen(props: GameplayScreenProps) {
   }
 
   return (
-    <section aria-label="Gameplay screen">
-      <header class="gameplay__header">
-        <h1>Game session</h1>
-        <p>
-          Round <strong>{displayedState().round}</strong>, phase{' '}
-          <strong>{displayedState().phase}</strong>
-        </p>
-        <p>
-          Deck: <strong>{displayedState().deck?.length ?? 0}</strong> ·
-          Graveyard: <strong>{displayedState().graveyard?.length ?? 0}</strong>{' '}
-          · Forbidden cells:{' '}
-          <strong>{displayedState().forbiddenCells.length}</strong>
-        </p>
+    <section class="gameplay-screen" aria-label="Gameplay screen">
+      <header class="gameplay-screen__header">
+        <div>
+          <h1>Game session</h1>
+          <p class="gameplay-screen__header-meta">
+            Round <strong>{displayedState().round}</strong> · phase{' '}
+            <strong>{displayedState().phase}</strong> · deck{' '}
+            <strong>{displayedState().deck?.length ?? 0}</strong> · graveyard{' '}
+            <strong>{displayedState().graveyard?.length ?? 0}</strong> ·
+            forbidden <strong>{displayedState().forbiddenCells.length}</strong>
+          </p>
+        </div>
+        <button
+          type="button"
+          class="gameplay-screen__menu"
+          onClick={toggleDrawer}
+          aria-label="Open auxiliary controls"
+          aria-expanded={drawerOpen()}
+        >
+          ☰
+        </button>
       </header>
-
-      <section class="gameplay__history" aria-label="State history">
-        <h2>History</h2>
-        <p>
-          Frame <strong>{viewIndex() + 1}</strong> / {history().length}
-          <Show when={isViewingHistory()}>
-            {' '}
-            — <em>viewing history</em>
-          </Show>
-        </p>
-        <button type="button" onClick={goPrev} disabled={viewIndex() === 0}>
-          ← Previous
-        </button>
-        <button
-          type="button"
-          onClick={goNext}
-          disabled={viewIndex() >= history().length - 1}
-        >
-          Next →
-        </button>
-        <button
-          type="button"
-          onClick={goLive}
-          disabled={!isViewingHistory()}
-          aria-label="Jump to live"
-        >
-          Jump to live
-        </button>
-        <label>
-          Frame:
-          <input
-            type="range"
-            min="0"
-            max={history().length - 1}
-            value={viewIndex()}
-            onInput={(e) => jumpToFrame(Number(e.currentTarget.value))}
-            aria-label="History timeline"
-          />
-        </label>
-      </section>
-
-      <Show when={isAllBot()}>
-        <section class="gameplay__autoplay" aria-label="Auto-play controls">
-          <h2>Auto-play</h2>
-          <button
-            type="button"
-            onClick={toggleAutoPlay}
-            disabled={over() || isViewingHistory()}
-          >
-            {autoPlayActive() ? 'Pause' : 'Play'}
-          </button>
-          <label>
-            Delay (ms):
-            <input
-              type="range"
-              min={MIN_AUTOPLAY_DELAY_MS}
-              max={MAX_AUTOPLAY_DELAY_MS}
-              step="50"
-              value={autoPlayDelayMs()}
-              onInput={(e) => setAutoPlayDelayMs(Number(e.currentTarget.value))}
-              aria-label="Auto-play delay milliseconds"
-            />
-            <output>{autoPlayDelayMs()}</output>
-          </label>
-        </section>
-      </Show>
 
       <GameGrid
         grid={displayedState().grid}
@@ -434,42 +385,51 @@ export function GameplayScreen(props: GameplayScreenProps) {
         currentPhase={displayedState().phase}
       />
 
-      <section aria-label="Surviving teams">
+      <section
+        aria-label="Surviving teams"
+        class="gameplay-screen__teams-section"
+      >
         <h2>Teams</h2>
-        <For each={livingTeams()}>
-          {(team) => (
-            <article
-              class="gameplay__team"
-              aria-label={`Team ${team.teamNumber}`}
-            >
-              <header>
-                <h3>Team {team.teamNumber}</h3>
-                <p>
-                  Position: ({team.position.x}, {team.position.y}) · Facing:{' '}
-                  {team.facing} · Total life: {teamLife(team)}
-                </p>
-              </header>
-              <Show when={team.gridCards !== undefined}>
-                <fieldset class="gameplay__grid-cards">
-                  <legend>Grid cards</legend>
-                  <CardFace card={team.gridCards?.[0] as Card} />
-                  <CardFace card={team.gridCards?.[1] as Card} />
-                </fieldset>
-              </Show>
-              <Hand
-                cards={[...team.cards]}
-                label={`Team ${team.teamNumber} hand`}
-                faceUp={true}
-              />
-            </article>
-          )}
-        </For>
+        <ul class="gameplay-screen__teams">
+          <For each={livingTeams()}>
+            {(team) => (
+              <li>
+                <article
+                  class="gameplay-screen__team"
+                  aria-label={`Team ${team.teamNumber}`}
+                >
+                  <header>
+                    <h3>Team {team.teamNumber}</h3>
+                    <p>
+                      Position: ({team.position.x}, {team.position.y}) · Facing:{' '}
+                      {team.facing} · Total life: {teamLife(team)}
+                    </p>
+                  </header>
+                  <Show when={team.gridCards !== undefined}>
+                    <fieldset class="gameplay__grid-cards">
+                      <legend>Grid cards</legend>
+                      <CardFace card={team.gridCards?.[0] as Card} />
+                      <CardFace card={team.gridCards?.[1] as Card} />
+                    </fieldset>
+                  </Show>
+                  <Hand
+                    cards={[...team.cards]}
+                    label={`Team ${team.teamNumber} hand`}
+                    faceUp={true}
+                  />
+                </article>
+              </li>
+            )}
+          </For>
+        </ul>
       </section>
 
       <Show when={pending() !== null && !over() && !isViewingHistory()}>
         <section
-          class="gameplay__input"
+          class="gameplay__input gameplay-screen__sheet"
           aria-label={`Phase input — ${pending()?.phase}`}
+          role="dialog"
+          aria-modal="false"
         >
           <h2>Awaiting input — {pending()?.phase}</h2>
 
@@ -681,6 +641,110 @@ export function GameplayScreen(props: GameplayScreenProps) {
       </Show>
 
       <TurnLog entries={[...log()]} />
+
+      <Show when={drawerOpen()}>
+        <button
+          type="button"
+          class="gameplay-screen__drawer-scrim"
+          aria-label="Close auxiliary controls"
+          onClick={closeDrawer}
+        />
+        <aside class="gameplay-screen__drawer" aria-label="Auxiliary controls">
+          <header class="gameplay-screen__drawer-header">
+            <h2>Controls</h2>
+            <button
+              type="button"
+              class="gameplay-screen__drawer-close"
+              onClick={closeDrawer}
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </header>
+
+          <section
+            class="gameplay-screen__drawer-section"
+            aria-label="State history"
+          >
+            <h3>History</h3>
+            <p>
+              Frame <strong>{viewIndex() + 1}</strong> / {history().length}
+              <Show when={isViewingHistory()}>
+                {' '}
+                — <em>viewing history</em>
+              </Show>
+            </p>
+            <div class="gameplay-screen__drawer-controls">
+              <button
+                type="button"
+                onClick={goPrev}
+                disabled={viewIndex() === 0}
+              >
+                ← Previous
+              </button>
+              <button
+                type="button"
+                onClick={goNext}
+                disabled={viewIndex() >= history().length - 1}
+              >
+                Next →
+              </button>
+              <button
+                type="button"
+                onClick={goLive}
+                disabled={!isViewingHistory()}
+                aria-label="Jump to live"
+              >
+                Jump to live
+              </button>
+            </div>
+            <label>
+              Frame:
+              <input
+                type="range"
+                min="0"
+                max={history().length - 1}
+                value={viewIndex()}
+                onInput={(e) => jumpToFrame(Number(e.currentTarget.value))}
+                aria-label="History timeline"
+              />
+            </label>
+          </section>
+
+          <Show when={isAllBot()}>
+            <section
+              class="gameplay-screen__drawer-section"
+              aria-label="Auto-play controls"
+            >
+              <h3>Auto-play</h3>
+              <div class="gameplay-screen__drawer-controls">
+                <button
+                  type="button"
+                  onClick={toggleAutoPlay}
+                  disabled={over() || isViewingHistory()}
+                >
+                  {autoPlayActive() ? 'Pause' : 'Play'}
+                </button>
+              </div>
+              <label>
+                Delay (ms):
+                <input
+                  type="range"
+                  min={MIN_AUTOPLAY_DELAY_MS}
+                  max={MAX_AUTOPLAY_DELAY_MS}
+                  step="50"
+                  value={autoPlayDelayMs()}
+                  onInput={(e) =>
+                    setAutoPlayDelayMs(Number(e.currentTarget.value))
+                  }
+                  aria-label="Auto-play delay milliseconds"
+                />
+                <output>{autoPlayDelayMs()}</output>
+              </label>
+            </section>
+          </Show>
+        </aside>
+      </Show>
     </section>
   );
 }

--- a/packages/web/src/screens/gameplay-screen.css
+++ b/packages/web/src/screens/gameplay-screen.css
@@ -1,0 +1,300 @@
+/*
+ * Mobile-first layout for GameplayScreen.
+ *
+ * Structure: a vertical scrollable main view (header → grid →
+ * team list → log) with a top-right hamburger that opens an
+ * off-canvas drawer carrying auxiliary controls (history +
+ * auto-play). The phase input is a sticky bottom sheet that
+ * slides in when the session emits an awaiting request and
+ * retracts when submission advances the phase or the game ends.
+ *
+ * Tap-targets respect --touch-min from tokens.css. The screen
+ * stays single-column on tablet/desktop, only growing the
+ * container width via the max-width cap.
+ */
+
+.gameplay-screen {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  max-width: min(720px, 100%);
+  margin: 0 auto;
+  padding: var(--space-3);
+  padding-bottom: calc(var(--space-7) + var(--touch-min) * 2);
+}
+
+.gameplay-screen__header {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  margin: 0;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.gameplay-screen__header > h1 {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: var(--type-heading-2);
+}
+
+.gameplay-screen__header-meta {
+  margin: var(--space-1) 0 0;
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.gameplay-screen__menu {
+  flex: 0 0 auto;
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-bg-elevated);
+  color: var(--color-fg);
+  font-size: var(--type-body);
+  cursor: pointer;
+}
+
+.gameplay-screen__menu:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.gameplay-screen__teams {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.gameplay-screen__team {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2);
+  background: var(--color-bg-elevated);
+}
+
+.gameplay-screen__team > header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.gameplay-screen__team > header h3 {
+  margin: 0;
+  font-size: var(--type-heading-3);
+}
+
+.gameplay__grid-cards {
+  display: flex;
+  gap: var(--space-2);
+  margin: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+}
+
+.gameplay__grid-cards > legend {
+  padding: 0 var(--space-1);
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+/* --- Bottom-sheet phase input -------------------------------- */
+
+.gameplay-screen__sheet {
+  position: fixed;
+  inset: auto 0 0 0;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-height: 70vh;
+  padding: var(--space-4);
+  padding-bottom: calc(var(--space-4) + env(safe-area-inset-bottom, 0px));
+  background: var(--color-bg-elevated);
+  border-top: 1px solid var(--color-border);
+  border-radius: var(--radius-3) var(--radius-3) 0 0;
+  box-shadow: var(--shadow-2);
+  overflow-y: auto;
+}
+
+.gameplay-screen__sheet > h2 {
+  margin: 0;
+  font-size: var(--type-heading-3);
+}
+
+.gameplay-screen__sheet fieldset {
+  margin: 0;
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+}
+
+.gameplay-screen__sheet fieldset > legend {
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.gameplay-screen__sheet label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--touch-min);
+  padding: var(--space-1) 0;
+}
+
+.gameplay-screen__sheet input[type="radio"],
+.gameplay-screen__sheet select {
+  min-height: var(--touch-min);
+}
+
+.gameplay-screen__sheet > button[type="button"] {
+  min-height: var(--touch-min);
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  border: none;
+  border-radius: var(--radius-2);
+  background: var(--color-accent);
+  color: white;
+  font-size: var(--type-heading-3);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+/* --- Off-canvas drawer -------------------------------------- */
+
+.gameplay-screen__drawer-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: var(--color-scrim);
+}
+
+.gameplay-screen__drawer {
+  position: fixed;
+  inset: 0 0 0 auto;
+  z-index: 31;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  width: min(90vw, 320px);
+  padding: var(--space-4);
+  padding-top: calc(var(--space-4) + env(safe-area-inset-top, 0px));
+  background: var(--color-bg-elevated);
+  border-left: 1px solid var(--color-border);
+  box-shadow: var(--shadow-2);
+  overflow-y: auto;
+}
+
+.gameplay-screen__drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin: 0;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.gameplay-screen__drawer-header h2 {
+  margin: 0;
+  font-size: var(--type-heading-2);
+}
+
+.gameplay-screen__drawer-close {
+  min-width: var(--touch-min);
+  min-height: var(--touch-min);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  cursor: pointer;
+}
+
+.gameplay-screen__drawer-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.gameplay-screen__drawer-section h3 {
+  margin: 0;
+  font-size: var(--type-heading-3);
+}
+
+.gameplay-screen__drawer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.gameplay-screen__drawer-controls > button {
+  flex: 1 1 8rem;
+  min-height: var(--touch-min);
+  padding: var(--space-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  background: var(--color-bg);
+  color: var(--color-fg);
+  font-size: var(--type-small);
+  cursor: pointer;
+}
+
+.gameplay-screen__drawer-controls > button:disabled {
+  background: var(--color-border);
+  color: var(--color-fg-muted);
+  cursor: not-allowed;
+}
+
+.gameplay-screen__drawer label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.gameplay-screen__drawer input[type="range"] {
+  width: 100%;
+  min-height: var(--touch-min);
+}
+
+/* --- History banner + game-over panel ------------------------ */
+
+.gameplay__history-banner {
+  margin: 0;
+  padding: var(--space-3);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-1);
+  background: var(--color-bg);
+  font-size: var(--type-small);
+  color: var(--color-fg-muted);
+}
+
+.gameplay__game-over {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border: 2px solid var(--color-accent);
+  border-radius: var(--radius-2);
+  background: color-mix(
+    in srgb,
+    var(--color-accent) 8%,
+    var(--color-bg-elevated)
+  );
+}
+
+.gameplay__game-over h2 {
+  margin: 0;
+}


### PR DESCRIPTION
Closes #149 · Refs roadmap #145 · Builds on #146, #147

Final mobile layout for wave-8. The gameplay surface now drives
phase input as a sticky bottom sheet and hosts auxiliary
controls (history scrubber, auto-play) in an off-canvas drawer
behind a hamburger button. Every behavioural promise from
wave-6 + #141 still holds; the visual choreography just matches
the roadmap's claude-chosen skeleton.

## Summary

- **\`packages/web/src/screens/gameplay-screen.css\` (new)** —
  root layout, hamburger button, bottom-sheet
  (\`position: fixed; inset: auto 0 0 0; max-height: 70vh;
  env(safe-area-inset-bottom)\`), off-canvas drawer with scrim,
  team-list cards. Honours \`--touch-min\` everywhere.
- **\`GameplayScreen.tsx\`** restructured:
  - Compact one-row header (round / phase / deck / graveyard /
    forbidden counts) plus a top-right hamburger that toggles
    the new \`drawerOpen\` signal (with \`aria-expanded\`).
  - History scrubber + auto-play moved into a conditionally
    rendered \`<aside aria-label="Auxiliary controls">\` drawer.
    Scrim + in-drawer × both close.
  - Phase-input panel gains
    \`class="gameplay__input gameplay-screen__sheet"\` +
    \`role="dialog"\`, no behavioural change.
  - Team list wrapped in \`<ul class="gameplay-screen__teams">\`
    with each team as a \`<li><article class="gameplay-screen__team">\`.
- **\`index.tsx\`** imports the new stylesheet.

## Test plan

- [x] \`pnpm run test\` — **310 tests pass**
  - 4 existing tests adapted to open the drawer before
    clicking history / auto-play buttons (matches actual user
    flow).
  - New \`mobile layout\` describe block:
    - Phase input renders as a \`role="dialog"\` with the
      \`gameplay-screen__sheet\` class when awaiting.
    - Hamburger flips its own \`aria-expanded\`, mounts /
      unmounts the drawer, and the in-drawer × closes it.
    - Auto-play driven from inside the drawer still advances
      rounds.
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an auxiliary controls drawer accessible via a menu button, featuring history navigation controls and auto-play functionality for all-bot sessions.
  * Implemented mobile-optimized layout with a bottom-sheet phase input dialog and off-canvas drawer for improved usability.

* **Tests**
  * Updated and expanded test coverage for drawer interactions and mobile layout scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->