### PR TITLE
ci(web): deploy @kurone-kito/oneiron-web to GitHub Pages on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+concurrency:
+  # `cancel-in-progress: false` lets an in-flight deploy finish even
+  # if a newer push lands — Pages doesn't gracefully cancel mid-deploy.
+  cancel-in-progress: false
+  group: pages
+name: Deploy web simulator to GitHub Pages
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+run-name: Deploy web simulator triggered by @${{ github.actor }}
+jobs:
+  build-and-deploy:
+    name: Build and deploy
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Stages the pushed branch
+        uses: actions/checkout@v6
+      - name: Setup the pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          run_install: false
+      - name: Prepare the Node.js 24.x environment
+        uses: actions/setup-node@v6
+        with:
+          cache: pnpm
+          check-latest: true
+          node-version: 24.x
+      - env:
+          HUSKY: 0
+        name: Install the dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+      - env:
+          WEB_BASE: /oneiron/
+        name: Build the web simulator with the GitHub Pages base
+        run: pnpm --filter @kurone-kito/oneiron-web run build
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+      - name: Upload the dist directory as the Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: packages/web/dist
+      - id: deployment
+        name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+    timeout-minutes: 10

--- a/packages/web/README.ja.md
+++ b/packages/web/README.ja.md
@@ -40,6 +40,33 @@ Vite の [`base`](https://vite.dev/config/shared-options.html#base)
 は manifest-relative URL (`./icon-192.png` 等) を使うため、
 ベースパスが何であっても build 時の書き換え無しで追従します。
 
+## デプロイ
+
+シミュレーターは GitHub Pages 上の
+[`https://kurone-kito.github.io/oneiron/`](https://kurone-kito.github.io/oneiron/)
+で公開されます。
+
+- **自動デプロイ**: `main` への push で
+  [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml)
+  がトリガーされ、`WEB_BASE=/oneiron/` でビルドして
+  `packages/web/dist/` を GitHub Pages 公式 actions
+  (`actions/configure-pages` + `upload-pages-artifact` +
+  `deploy-pages`) で公開します。
+- **手動再デプロイ**:
+
+  ```sh
+  gh workflow run "Deploy web simulator to GitHub Pages"
+  ```
+
+  あるいは
+  [Actions タブ](https://github.com/kurone-kito/oneiron/actions/workflows/deploy.yml)
+  の **Run workflow** ボタンから実行できます。
+
+リポジトリの Pages source は **GitHub Actions** に維持されている
+必要があります
+([Settings → Pages](https://github.com/kurone-kito/oneiron/settings/pages))。
+ブランチ source へ戻すとこの workflow は機能しなくなります。
+
 ## モバイル端末へのインストール
 
 ビルド・配信されたインスタンスは、ブラウザ標準の PWA インストール

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -40,6 +40,30 @@ plus the PWA service-worker registration scope. The hand-written
 uses manifest-relative URLs (`./icon-192.png` etc.) so it adapts
 to any base path without a build-time rewrite.
 
+## Deployment
+
+The simulator is published to GitHub Pages at
+[`https://kurone-kito.github.io/oneiron/`](https://kurone-kito.github.io/oneiron/).
+
+- **Automatic**: every push to `main` triggers
+  [`.github/workflows/deploy.yml`](../../.github/workflows/deploy.yml),
+  which builds with `WEB_BASE=/oneiron/` and publishes the
+  `packages/web/dist/` artifact via the official Pages actions
+  (`actions/configure-pages` + `upload-pages-artifact` +
+  `deploy-pages`).
+- **Manual re-run**:
+
+  ```sh
+  gh workflow run "Deploy web simulator to GitHub Pages"
+  ```
+
+  Or use the **Run workflow** button on
+  [the Actions tab](https://github.com/kurone-kito/oneiron/actions/workflows/deploy.yml).
+
+The repository's Pages source must remain **GitHub Actions**
+(see [Settings → Pages](https://github.com/kurone-kito/oneiron/settings/pages));
+switching back to a branch source disables this workflow.
+
 ## Installing as a mobile app
 
 A built-and-served instance of this package can be added to a


### PR DESCRIPTION
Closes #161 · Refs roadmap #158 · Builds on #159 (closed), #160 (closed)

With #159 unblocking the repo-side Pages settings and #160
making the build subpath-aware, this issue adds the workflow
that publishes the simulator to
[`https://kurone-kito.github.io/oneiron/`](https://kurone-kito.github.io/oneiron/).

## Summary

- **\`.github/workflows/deploy.yml\` (new)** — single
  \`build-and-deploy\` job on \`ubuntu-24.04-arm\` (matches the
  CI matrix's modal arm runner). Triggers: \`push: branches:
  [main]\` and \`workflow_dispatch\`. Permissions: \`contents:
  read\` + \`pages: write\` + \`id-token: write\` (OIDC).
  \`concurrency: { group: pages, cancel-in-progress: false }\`
  so in-flight deploys aren't cancelled by newer pushes.
- Steps mirror \`push.yml\`'s pnpm + Node 24.x setup, then
  build with \`WEB_BASE=/oneiron/\` (consumes #160), then
  \`actions/configure-pages@v5\` → \`upload-pages-artifact@v3\`
  → \`deploy-pages@v4\` against \`packages/web/dist\`.
- **README + README.ja** gain a \`## Deployment\` section
  covering the auto-trigger, the
  \`gh workflow run "Deploy web simulator to GitHub Pages"\`
  manual path, the live URL, and a reminder that the repo's
  Pages source must stay on **GitHub Actions**.

## Test plan

- [x] \`pnpm run test\` — **316 tests pass**
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean
- [x] Workflow YAML parsed by \`yaml@2.9.0\`: top-level keys
      \`concurrency, jobs, name, on, permissions, run-name\`,
      triggers \`push, workflow_dispatch\`, one job with 8
      steps.
- [ ] *(deferred to post-merge)* First deploy run on \`main\`
      succeeds and \`https://kurone-kito.github.io/oneiron/\`
      serves the live build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)