### PR TITLE
chore(ci): bump GitHub Pages actions to the Node.js 24 majors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,12 +42,12 @@ jobs:
         name: Build the web simulator with the GitHub Pages base
         run: pnpm --filter @kurone-kito/oneiron-web run build
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload the dist directory as the Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: packages/web/dist
       - id: deployment
         name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
     timeout-minutes: 10


### PR DESCRIPTION
Closes #164

Bumps the three Pages actions in
\`.github/workflows/deploy.yml\` to the upstream majors that
ship with Node.js 24, silencing the *"Node.js 20 actions are
deprecated"* annotation observed on the first wave-9 deploy
run.

## Diff

```diff
- uses: actions/configure-pages@v5
+ uses: actions/configure-pages@v6
- uses: actions/upload-pages-artifact@v3
+ uses: actions/upload-pages-artifact@v5
- uses: actions/deploy-pages@v4
+ uses: actions/deploy-pages@v5
```

No other workflow changes — build step, permissions block,
\`concurrency: { group: pages, cancel-in-progress: false }\`,
and the step ordering are all unchanged.

## Test plan

- [x] YAML re-parsed with \`yaml@2.9.0\`: top-level keys
      unchanged, 8 job steps, the three pages references read
      \`@v6\`, \`@v5\`, \`@v5\`.
- [x] \`pnpm run test\` — 316 tests pass (workflow change is
      orthogonal to the test suite).
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web.
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean.
- [ ] *(deferred to post-merge)* Next deploy run on \`main\`
      finishes \`success\` with the Node 20 deprecation
      annotation gone, and
      \`https://kurone-kito.github.io/oneiron/\` still serves the
      live build.

## Reference

- Original deprecation observation: deploy run
  [26330431547](https://github.com/kurone-kito/oneiron/actions/runs/26330431547)
- Wave-9 roadmap (closed): #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow with latest GitHub Actions versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->