### PR TITLE
fix(web): re-read grid + forbidden cell reactively in GameGrid (closes #167)

### DIFF
--- a/packages/web/src/components/Grid.tsx
+++ b/packages/web/src/components/Grid.tsx
@@ -69,15 +69,23 @@ export function GameGrid(props: Props) {
                 <th class="game-grid__row-label">{y}</th>
                 <For each={[...ELEMENT_AXIS]}>
                   {(x) => {
+                    // `props.forbiddenCells` and `props.grid` are
+                    // Solid reactive sources via the props proxy.
+                    // Reading them inside getter / JSX expressions
+                    // keeps the cell reactive across round
+                    // transitions; binding them to plain `const`s
+                    // here would snapshot the values on first
+                    // render and never refresh — that was the
+                    // "bots don't appear to move" bug from #167.
                     const coord: GridCoord = { x, y };
-                    const forbidden = isForbidden(coord, props.forbiddenCells);
-                    const teams = props.grid[x][y];
+                    const isCellForbidden = () =>
+                      isForbidden(coord, props.forbiddenCells);
                     return (
                       <td
-                        class={`game-grid__cell${forbidden ? ' game-grid__cell--forbidden' : ''}`}
-                        aria-label={`${x},${y}${forbidden ? ' (forbidden)' : ''}`}
+                        class={`game-grid__cell${isCellForbidden() ? ' game-grid__cell--forbidden' : ''}`}
+                        aria-label={`${x},${y}${isCellForbidden() ? ' (forbidden)' : ''}`}
                       >
-                        <CellContent teams={teams} />
+                        <CellContent teams={props.grid[x][y]} />
                       </td>
                     );
                   }}

--- a/packages/web/src/screens/GameplayScreen.test.tsx
+++ b/packages/web/src/screens/GameplayScreen.test.tsx
@@ -371,5 +371,73 @@ describe('GameplayScreen', () => {
         vi.useRealTimers();
       }
     });
+
+    it('renders bots in new grid cells after auto-play drives several rounds', async () => {
+      // Mirrors the engine-side spot-check from #166 / #167: an
+      // all-bot session at the same seed should reach the DOM
+      // with at least one team chip in a different cell after a
+      // handful of rounds. If this assertion fails on `main`,
+      // the engine is fine (covered by packages/cli/src/e2e.test.ts)
+      // but `GameplayScreen` isn't propagating `displayedState`
+      // changes to the rendered `<GameGrid>` — that's the bug
+      // the maintainer observed.
+      vi.useFakeTimers();
+      try {
+        const initial = setupGame({ playerCount: 6, seed: 7 }, DEFAULT_CONFIG);
+        const config = botConfigFor(initial, 0);
+        render(() => <GameplayScreen initialState={initial} config={config} />);
+
+        const snapshotPositions = (): ReadonlyMap<string, string> => {
+          const map = new Map<string, string>();
+          // Each team chip carries `aria-label="Team N"`; the
+          // enclosing `<td>` in `<GameGrid>` carries
+          // `aria-label="<x>,<y>"` (optionally suffixed with
+          // " (forbidden)"). We walk up to that cell to read
+          // the position.
+          for (const chip of Array.from(
+            document.querySelectorAll('[aria-label^="Team "]'),
+          )) {
+            const cell = chip.closest('td[aria-label]');
+            if (!cell) continue;
+            const cellLabel = cell.getAttribute('aria-label') ?? '';
+            // Only match cells inside the grid (the team summary
+            // cards under "Surviving teams" also use
+            // `Team N` aria-labels but live in <article>s).
+            if (!/^(fire|water|wood),(fire|water|wood)/.test(cellLabel)) {
+              continue;
+            }
+            map.set(
+              chip.getAttribute('aria-label') ?? '',
+              cellLabel.replace(/\s*\(forbidden\)$/, ''),
+            );
+          }
+          return map;
+        };
+
+        const before = snapshotPositions();
+        expect(before.size).toBeGreaterThan(0);
+
+        fireEvent.click(
+          screen.getByRole('button', { name: /Open auxiliary controls/i }),
+        );
+        fireEvent.click(screen.getByRole('button', { name: 'Play' }));
+        // Default auto-play delay is 200 ms; allow several rounds.
+        await vi.advanceTimersByTimeAsync(1500);
+        fireEvent.click(screen.getByRole('button', { name: 'Pause' }));
+
+        const after = snapshotPositions();
+
+        const moved = [...after.entries()].filter(
+          ([team, pos]) =>
+            before.get(team) !== undefined && before.get(team) !== pos,
+        );
+        expect(
+          moved.length,
+          `expected at least one team chip to be in a new cell after auto-play; before=${JSON.stringify([...before])} after=${JSON.stringify([...after])}`,
+        ).toBeGreaterThan(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #167

The maintainer's *"bots don't appear to move on the grid"*
observation was a real SolidJS reactivity bug, not a UI
perception issue. The new test from #167 reproduces it
deterministically.

## Root cause

\`packages/web/src/components/Grid.tsx\` bound the per-cell
\`teams\` and \`forbidden\` values as plain \`const\`s inside the
inner \`<For each={[...ELEMENT_AXIS]}>\` callback:

\`\`\`tsx
{(x) => {
  const coord: GridCoord = { x, y };
  const forbidden = isForbidden(coord, props.forbiddenCells);
  const teams = props.grid[x][y];          // <-- snapshot once
  return (
    <td class={`game-grid__cell${forbidden ? ' …' : ''}`} …>
      <CellContent teams={teams} />
    </td>
  );
}}
\`\`\`

That callback only re-runs when its iterated array contents
change — and \`ELEMENT_AXIS\` is a constant. So each of the
nine cells captured the **initial-frame** \`props.grid[x][y]\`
once and never refreshed, even though \`GameplayScreen\` was
passing a live \`displayedState().grid\` down on every history
advance.

The engine layer was correct all along (confirmed by both
the engine spot-check during issue authoring and by
\`packages/cli/src/e2e.test.ts\` from #166).

## Fix

Move the reactive reads back into JSX expressions / getters,
which Solid wraps as tracked computations:

\`\`\`tsx
const isCellForbidden = () =>
  isForbidden(coord, props.forbiddenCells);
return (
  <td
    class={`game-grid__cell${isCellForbidden() ? ' …' : ''}`}
    aria-label={`${x},${y}${isCellForbidden() ? ' (forbidden)' : ''}`}
  >
    <CellContent teams={props.grid[x][y]} />
  </td>
);
\`\`\`

An inline comment documents the trap so future edits don't
regress.

## New regression test

\`GameplayScreen.test.tsx\` gains the *"renders bots in new
grid cells after auto-play drives several rounds"* case under
the existing \`mobile layout\` describe block. It:

1. Renders the all-bot \`seed=7\` session (same fixture as the
   engine-side spot-check).
2. Snapshots every team chip's parent cell label via
   \`document.querySelectorAll('[aria-label^="Team "]')\` +
   \`.closest('td[aria-label]')\`.
3. Opens the drawer, clicks Play, advances 1.5 s at the
   default 200 ms tick.
4. Snapshots again and asserts at least one team is in a new
   cell. The failure message dumps the before / after maps so
   any future regression diagnoses itself.

The test **fails on \`main\` before this fix** and **passes
with the fix**.

## Test plan

- [x] New test reproduces the bug on the pre-fix code (before /
      after maps identical).
- [x] Fix makes the new test pass; all other
      \`GameplayScreen.test.tsx\` cases still pass.
- [x] \`pnpm run test\` — **317 tests pass** (+1 from this PR).
- [x] \`pnpm -r run typecheck\` — clean across core / cli / web.
- [x] \`pnpm run lint\` — biome / markdown / cspell all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the game state wasn't properly updating during gameplay transitions, causing bots to not appear to move correctly on the game board.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kurone-kito/oneiron/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->